### PR TITLE
Add Growset module with backend sync and API endpoints

### DIFF
--- a/modules/growset/composer.json
+++ b/modules/growset/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "growset/module",
+    "description": "Growset integration module",
+    "type": "prestashop-module",
+    "require": {
+        "guzzlehttp/guzzle": "^7.8"
+    },
+    "autoload": {
+        "psr-4": {
+            "Growset\\": "src/"
+        }
+    }
+}

--- a/modules/growset/growset.php
+++ b/modules/growset/growset.php
@@ -1,0 +1,6 @@
+<?php
+require_once __DIR__ . '/vendor/autoload.php';
+
+class Growset extends \Growset\Growset
+{
+}

--- a/modules/growset/src/Controller/Admin/SyncProductsController.php
+++ b/modules/growset/src/Controller/Admin/SyncProductsController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Growset\Controller\Admin;
+
+use ModuleAdminController;
+
+class SyncProductsController extends ModuleAdminController
+{
+    public function initContent()
+    {
+        parent::initContent();
+        $this->executeSync();
+        $this->content = '<p>Sync triggered.</p>';
+        $this->context->smarty->assign('content', $this->content);
+    }
+
+    protected function executeSync(): void
+    {
+        $cmd = _PS_ROOT_DIR_ . '/bin/console growset:sync';
+        if (function_exists('exec')) {
+            @exec('php ' . escapeshellcmd($cmd) . ' > /dev/null 2>&1 &');
+        }
+    }
+}
+

--- a/modules/growset/src/Controller/Api/FiltersController.php
+++ b/modules/growset/src/Controller/Api/FiltersController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Growset\Controller\Api;
+
+use Cache;
+use Growset\Service\BackendClient;
+use ModuleFrontController;
+use Tools;
+
+class FiltersController extends ModuleFrontController
+{
+    public $ssl = true;
+
+    public function initContent()
+    {
+        parent::initContent();
+
+        $page = (int) Tools::getValue('page', 1);
+        $limit = (int) Tools::getValue('limit', 20);
+        $cacheKey = sprintf('growset_filters_%d_%d', $page, $limit);
+        $ttl = 300;
+
+        $content = Cache::retrieve($cacheKey);
+        if (!$content) {
+            $client = new BackendClient();
+            $data = $client->getFilters($page, $limit);
+            $content = json_encode([
+                'page' => $page,
+                'limit' => $limit,
+                'data' => $data,
+            ]);
+            Cache::store($cacheKey, $content, $ttl);
+        }
+
+        $etag = md5($content);
+        header('Content-Type: application/json');
+        header('Cache-Control: max-age=' . $ttl);
+        header('ETag: ' . $etag);
+        if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']) === $etag) {
+            header('HTTP/1.1 304 Not Modified');
+            exit;
+        }
+
+        echo $content;
+        exit;
+    }
+}
+

--- a/modules/growset/src/Controller/Api/ProductsController.php
+++ b/modules/growset/src/Controller/Api/ProductsController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Growset\Controller\Api;
+
+use Cache;
+use Growset\Service\BackendClient;
+use ModuleFrontController;
+use Tools;
+
+class ProductsController extends ModuleFrontController
+{
+    public $ssl = true;
+
+    public function initContent()
+    {
+        parent::initContent();
+
+        $page = (int) Tools::getValue('page', 1);
+        $limit = (int) Tools::getValue('limit', 20);
+        $cacheKey = sprintf('growset_products_%d_%d', $page, $limit);
+        $ttl = 300;
+
+        $content = Cache::retrieve($cacheKey);
+        if (!$content) {
+            $client = new BackendClient();
+            $data = $client->getProducts($page, $limit);
+            $content = json_encode([
+                'page' => $page,
+                'limit' => $limit,
+                'data' => $data,
+            ]);
+            Cache::store($cacheKey, $content, $ttl);
+        }
+
+        $etag = md5($content);
+        header('Content-Type: application/json');
+        header('Cache-Control: max-age=' . $ttl);
+        header('ETag: ' . $etag);
+
+        if (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']) === $etag) {
+            header('HTTP/1.1 304 Not Modified');
+            exit;
+        }
+
+        echo $content;
+        exit;
+    }
+}
+

--- a/modules/growset/src/Growset.php
+++ b/modules/growset/src/Growset.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Growset;
+
+use Cache;
+use Configuration;
+use Module;
+use Tools;
+
+class Growset extends Module
+{
+    public const CONFIG_CATEGORY_IDS = 'GROWSET_CATEGORY_IDS';
+    public const CONFIG_BACKEND_URL = 'GROWSET_BACKEND_URL';
+    public const CONFIG_TOKEN = 'GROWSET_BACKEND_TOKEN';
+
+    public function __construct()
+    {
+        $this->name = 'growset';
+        $this->tab = 'administration';
+        $this->version = '1.0.0';
+        $this->author = 'Growset';
+        $this->need_instance = 0;
+
+        parent::__construct();
+
+        $this->displayName = $this->l('Growset');
+        $this->description = $this->l('Synchronizes products with the Growset backend.');
+    }
+
+    public function install()
+    {
+        return parent::install()
+            && $this->registerHook('actionProductAdd')
+            && $this->registerHook('actionProductUpdate')
+            && $this->registerHook('actionProductDelete');
+    }
+
+    public function uninstall()
+    {
+        Configuration::deleteByName(self::CONFIG_CATEGORY_IDS);
+        Configuration::deleteByName(self::CONFIG_BACKEND_URL);
+        Configuration::deleteByName(self::CONFIG_TOKEN);
+
+        return parent::uninstall();
+    }
+
+    public function getContent()
+    {
+        $output = '';
+        if (Tools::isSubmit('submitGrowset')) {
+            Configuration::updateValue(self::CONFIG_CATEGORY_IDS, Tools::getValue(self::CONFIG_CATEGORY_IDS));
+            Configuration::updateValue(self::CONFIG_BACKEND_URL, Tools::getValue(self::CONFIG_BACKEND_URL));
+            Configuration::updateValue(self::CONFIG_TOKEN, Tools::getValue(self::CONFIG_TOKEN));
+            $output .= $this->displayConfirmation($this->l('Settings updated'));
+        }
+
+        return $output . $this->renderForm();
+    }
+
+    protected function renderForm()
+    {
+        $defaultLang = (int) Configuration::get('PS_LANG_DEFAULT');
+
+        $fieldsForm[0]['form'] = [
+            'legend' => ['title' => $this->l('Settings')],
+            'input' => [
+                [
+                    'type' => 'text',
+                    'label' => $this->l('Category IDs'),
+                    'name' => self::CONFIG_CATEGORY_IDS,
+                    'desc' => $this->l('Comma separated category identifiers'),
+                ],
+                [
+                    'type' => 'text',
+                    'label' => $this->l('Backend URL'),
+                    'name' => self::CONFIG_BACKEND_URL,
+                ],
+                [
+                    'type' => 'text',
+                    'label' => $this->l('Backend token'),
+                    'name' => self::CONFIG_TOKEN,
+                ],
+            ],
+            'submit' => [
+                'title' => $this->l('Save'),
+                'class' => 'btn btn-default pull-right',
+            ],
+        ];
+
+        $helper = new \HelperForm();
+        $helper->module = $this;
+        $helper->identifier = $this->identifier;
+        $helper->submit_action = 'submitGrowset';
+        $helper->currentIndex = \AdminController::$currentIndex . '&configure=' . $this->name;
+        $helper->token = \Tools::getAdminTokenLite('AdminModules');
+        $helper->default_form_language = $defaultLang;
+
+        $helper->fields_value[self::CONFIG_CATEGORY_IDS] = Configuration::get(self::CONFIG_CATEGORY_IDS);
+        $helper->fields_value[self::CONFIG_BACKEND_URL] = Configuration::get(self::CONFIG_BACKEND_URL, getenv('GROWSET_BACKEND_URL'));
+        $helper->fields_value[self::CONFIG_TOKEN] = Configuration::get(self::CONFIG_TOKEN, getenv('GROWSET_BACKEND_TOKEN'));
+
+        return $helper->generateForm($fieldsForm);
+    }
+
+    public function hookActionProductAdd($params)
+    {
+        Cache::clean('growset_products');
+    }
+
+    public function hookActionProductUpdate($params)
+    {
+        Cache::clean('growset_products');
+    }
+
+    public function hookActionProductDelete($params)
+    {
+        Cache::clean('growset_products');
+    }
+}
+

--- a/modules/growset/src/Service/BackendClient.php
+++ b/modules/growset/src/Service/BackendClient.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Growset\Service;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use Growset\Growset;
+use Configuration;
+
+class BackendClient
+{
+    private Client $client;
+    private string $token;
+    private int $retries;
+
+    public function __construct(?string $baseUri = null, ?string $token = null, int $retries = 3)
+    {
+        $baseUri = $baseUri ?: (string) (Configuration::get(Growset::CONFIG_BACKEND_URL) ?: getenv('GROWSET_BACKEND_URL'));
+        $this->token = $token ?: (string) (Configuration::get(Growset::CONFIG_TOKEN) ?: getenv('GROWSET_BACKEND_TOKEN'));
+        $this->client = new Client(['base_uri' => $baseUri]);
+        $this->retries = $retries;
+    }
+
+    public function getProducts(int $page, int $limit): array
+    {
+        $response = $this->request('GET', '/products', ['query' => ['page' => $page, 'limit' => $limit]]);
+        return json_decode((string) $response->getBody(), true) ?: [];
+    }
+
+    public function getFilters(int $page, int $limit): array
+    {
+        $response = $this->request('GET', '/filters', ['query' => ['page' => $page, 'limit' => $limit]]);
+        return json_decode((string) $response->getBody(), true) ?: [];
+    }
+
+    private function request(string $method, string $uri, array $options)
+    {
+        $options['headers']['Authorization'] = 'Bearer ' . $this->token;
+        $attempts = 0;
+        $delay = 1;
+
+        start:
+        try {
+            return $this->client->request($method, $uri, $options);
+        } catch (RequestException $e) {
+            $attempts++;
+            if ($attempts > $this->retries) {
+                throw $e;
+            }
+            sleep($delay);
+            $delay *= 2;
+            goto start;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add Growset module with install/uninstall, configuration form and hooks
- Implement API controllers for products and filters with caching and pagination
- Introduce BackendClient using Guzzle with retry logic and admin sync controller

## Testing
- `php -l modules/growset/src/Growset.php`
- `php -l modules/growset/src/Controller/Api/ProductsController.php`
- `php -l modules/growset/src/Controller/Api/FiltersController.php`
- `php -l modules/growset/src/Service/BackendClient.php`
- `php -l modules/growset/src/Controller/Admin/SyncProductsController.php`
- `php -l modules/growset/growset.php`
- `composer validate modules/growset/composer.json`


------
https://chatgpt.com/codex/tasks/task_b_68bc0418e5bc8329afd68bfbb91d20e2