### PR TITLE
feat: add pagination and cache invalidation with react query

### DIFF
--- a/frontend/app/configurator/CategoryFacet.tsx
+++ b/frontend/app/configurator/CategoryFacet.tsx
@@ -3,22 +3,52 @@ import { fetchCategoryArticles } from "@/lib/api";
 import ArticleListItem from "@/components/ArticleListItem";
 import FacetPanel from "@/components/FacetPanel";
 import { useSelection } from "@/components/SelectionProvider";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 
 export default function CategoryFacet() {
   const { setSelection } = useSelection();
-  const { data } = fetchCategoryArticles("default", 1);
+  const queryClient = useQueryClient();
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: ["categoryArticles", "default"],
+    queryFn: ({ pageParam = 1, signal }) =>
+      fetchCategoryArticles("default", pageParam, 10, signal),
+    getNextPageParam: (lastPage) =>
+      lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
+    initialPageParam: 1,
+  });
+
+  const articles = data?.pages.flatMap((p) => p.items) ?? [];
 
   return (
     <FacetPanel title="Articles">
       <ul className="space-y-2">
-        {data?.items?.map((article) => (
+        {articles.map((article) => (
           <ArticleListItem
             key={article.id}
             article={article}
-            onSelect={(id) => setSelection("article", id)}
+            onSelect={(id) => {
+              setSelection("category", id);
+              queryClient.invalidateQueries({ queryKey: ["filterOptions"] });
+            }}
           />
         ))}
       </ul>
+      {hasNextPage && (
+        <button
+          className="mt-2 rounded bg-gray-200 px-3 py-1"
+          onClick={() => fetchNextPage()}
+          disabled={isFetchingNextPage}
+        >
+          {isFetchingNextPage ? "Loading..." : "Load more"}
+        </button>
+      )}
     </FacetPanel>
   );
 }
+

--- a/frontend/app/configurator/FiltersFacet.tsx
+++ b/frontend/app/configurator/FiltersFacet.tsx
@@ -2,15 +2,32 @@
 import { fetchFilterOptions } from "@/lib/api";
 import FacetPanel from "@/components/FacetPanel";
 import { useSelection } from "@/components/SelectionProvider";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 export default function FiltersFacet() {
-  const { setSelection } = useSelection();
-  const { data } = fetchFilterOptions("default", 1);
+  const { selections, setSelection } = useSelection();
+  const category = selections.category ?? "default";
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: ["filterOptions", category],
+    queryFn: ({ pageParam = 1, signal }) =>
+      fetchFilterOptions("default", pageParam, 10, signal),
+    getNextPageParam: (lastPage) =>
+      lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
+    initialPageParam: 1,
+  });
+
+  const options = data?.pages.flatMap((p) => p.items) ?? [];
 
   return (
     <FacetPanel title="Filters">
       <ul className="space-y-1">
-        {data?.items?.map((opt) => (
+        {options.map((opt) => (
           <li
             key={opt.value}
             className="cursor-pointer rounded p-2 hover:bg-gray-50"
@@ -20,6 +37,16 @@ export default function FiltersFacet() {
           </li>
         ))}
       </ul>
+      {hasNextPage && (
+        <button
+          className="mt-2 rounded bg-gray-200 px-3 py-1"
+          onClick={() => fetchNextPage()}
+          disabled={isFetchingNextPage}
+        >
+          {isFetchingNextPage ? "Loading..." : "Load more"}
+        </button>
+      )}
     </FacetPanel>
   );
 }
+

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { SelectionProvider } from "@/components/SelectionProvider";
+import QueryProvider from "@/components/QueryProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -26,7 +27,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <SelectionProvider>{children}</SelectionProvider>
+        <QueryProvider>
+          <SelectionProvider>{children}</SelectionProvider>
+        </QueryProvider>
       </body>
     </html>
   );

--- a/frontend/components/QueryProvider.tsx
+++ b/frontend/components/QueryProvider.tsx
@@ -1,0 +1,9 @@
+"use client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode, useState } from "react";
+
+export default function QueryProvider({ children }: { children: ReactNode }) {
+  const [client] = useState(() => new QueryClient());
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,9 +1,4 @@
-/* eslint-disable react-hooks/rules-of-hooks */
-import useSWR from "swr";
-
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "";
-
-const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 export interface Article {
   id: string;
@@ -17,15 +12,27 @@ export interface Pagination<T> {
   totalPages: number;
 }
 
-export function fetchCategoryArticles(category: string, page = 1) {
-  return useSWR<Pagination<Article>>(
-    `${API_BASE}/categories/${category}/articles?page=${page}`,
-    fetcher
+export async function fetchCategoryArticles(
+  category: string,
+  page = 1,
+  limit = 10,
+  signal?: AbortSignal
+): Promise<Pagination<Article>> {
+  const res = await fetch(
+    `${API_BASE}/categories/${category}/articles?page=${page}&limit=${limit}`,
+    { signal }
   );
+  if (!res.ok) throw new Error("Failed to fetch category articles");
+  return res.json();
 }
 
-export function fetchArticle(id: string) {
-  return useSWR<Article>(id ? `${API_BASE}/articles/${id}` : null, fetcher);
+export async function fetchArticle(
+  id: string,
+  signal?: AbortSignal
+): Promise<Article> {
+  const res = await fetch(`${API_BASE}/articles/${id}`, { signal });
+  if (!res.ok) throw new Error("Failed to fetch article");
+  return res.json();
 }
 
 export interface FilterOption {
@@ -33,9 +40,17 @@ export interface FilterOption {
   label: string;
 }
 
-export function fetchFilterOptions(facet: string, page = 1) {
-  return useSWR<Pagination<FilterOption>>(
-    `${API_BASE}/filters/${facet}?page=${page}`,
-    fetcher
+export async function fetchFilterOptions(
+  facet: string,
+  page = 1,
+  limit = 10,
+  signal?: AbortSignal
+): Promise<Pagination<FilterOption>> {
+  const res = await fetch(
+    `${API_BASE}/filters/${facet}?page=${page}&limit=${limit}`,
+    { signal }
   );
+  if (!res.ok) throw new Error("Failed to fetch filter options");
+  return res.json();
 }
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "next": "15.5.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "swr": "^2.3.6"
+    "swr": "^2.3.6",
+    "@tanstack/react-query": "^5.59.19"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- add paging and abortable fetches to api helpers
- integrate React Query with provider
- implement load-more pagination for articles and filters and invalidate cache on category change

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68bc170e7e448329bd8b55af3afa7d61