### PR TITLE
Use Symfony Process for product sync

### DIFF
--- a/modules/growset/src/Controller/Admin/SyncProductsController.php
+++ b/modules/growset/src/Controller/Admin/SyncProductsController.php
@@ -3,6 +3,7 @@
 namespace Growset\Controller\Admin;
 
 use ModuleAdminController;
+use Symfony\Component\Process\Process;
 
 class SyncProductsController extends ModuleAdminController
 {
@@ -10,15 +11,27 @@ class SyncProductsController extends ModuleAdminController
     {
         parent::initContent();
         $this->executeSync();
-        $this->content = '<p>Sync triggered.</p>';
-        $this->context->smarty->assign('content', $this->content);
+        if (empty($this->errors)) {
+            $this->content = '<p>Sync triggered.</p>';
+            $this->context->smarty->assign('content', $this->content);
+        }
     }
 
     protected function executeSync(): void
     {
-        $cmd = _PS_ROOT_DIR_ . '/bin/console growset:sync';
-        if (function_exists('exec')) {
-            @exec('php ' . escapeshellcmd($cmd) . ' > /dev/null 2>&1 &');
+        $console = _PS_ROOT_DIR_ . '/bin/console';
+        $process = new Process(['php', $console, 'growset:sync']);
+        $process->setTimeout(null);
+        $process->disableOutput();
+
+        try {
+            $process->start();
+        } catch (\Throwable $e) {
+            $message = sprintf('Sync command failed to start: %s', $e->getMessage());
+            $this->errors[] = $message;
+            if (class_exists('\\PrestaShopLogger')) {
+                \PrestaShopLogger::addLog($message, 3);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace suppressed `exec` call with Symfony Process when triggering growset sync
- Run sync command asynchronously with no timeout and log start failures via PrestaShopLogger and controller errors

## Testing
- `composer install --no-progress`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68bc8406eca4832987bd42dd335a5120