### PR TITLE
refactor: centralize product cache clearing

### DIFF
--- a/modules/growset/src/Growset.php
+++ b/modules/growset/src/Growset.php
@@ -102,19 +102,24 @@ class Growset extends Module
         return $helper->generateForm($fieldsForm);
     }
 
-    public function hookActionProductAdd($params)
+    private function clearProductCache(): void
     {
         Cache::clean('growset_products');
+    }
+
+    public function hookActionProductAdd($params)
+    {
+        $this->clearProductCache();
     }
 
     public function hookActionProductUpdate($params)
     {
-        Cache::clean('growset_products');
+        $this->clearProductCache();
     }
 
     public function hookActionProductDelete($params)
     {
-        Cache::clean('growset_products');
+        $this->clearProductCache();
     }
 }
 

--- a/modules/growset/tests/GrowsetTest.php
+++ b/modules/growset/tests/GrowsetTest.php
@@ -1,0 +1,58 @@
+<?php
+
+class Module
+{
+    public function __construct()
+    {
+    }
+
+    protected function l(string $str): string
+    {
+        return $str;
+    }
+}
+
+class Cache
+{
+    public static array $keys = [];
+
+    public static function clean(string $key): void
+    {
+        self::$keys[] = $key;
+    }
+}
+
+use Growset\Growset;
+use PHPUnit\Framework\TestCase;
+
+class GrowsetTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Cache::$keys = [];
+    }
+
+    public function testAddHookClearsCache(): void
+    {
+        $module = new Growset();
+        $module->hookActionProductAdd([]);
+
+        $this->assertSame(['growset_products'], Cache::$keys);
+    }
+
+    public function testUpdateHookClearsCache(): void
+    {
+        $module = new Growset();
+        $module->hookActionProductUpdate([]);
+
+        $this->assertSame(['growset_products'], Cache::$keys);
+    }
+
+    public function testDeleteHookClearsCache(): void
+    {
+        $module = new Growset();
+        $module->hookActionProductDelete([]);
+
+        $this->assertSame(['growset_products'], Cache::$keys);
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated `clearProductCache` helper
- reuse helper from product add/update/delete hooks
- cover hooks with cache-clearing tests

## Testing
- `cd modules/growset && composer test`


------
https://chatgpt.com/codex/tasks/task_b_68bc873eb6a48329bd893b46709a8296