### PR TITLE
Pass selected category to queries

### DIFF
--- a/frontend/app/configurator/CategoryFacet.tsx
+++ b/frontend/app/configurator/CategoryFacet.tsx
@@ -6,22 +6,19 @@ import { useSelection } from "@/components/SelectionProvider";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 
 export default function CategoryFacet() {
-  const { setSelection } = useSelection();
+  const { selections, setSelection } = useSelection();
+  const category = selections.category ?? "default";
   const queryClient = useQueryClient();
 
-  const {
-    data,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  } = useInfiniteQuery({
-    queryKey: ["categoryArticles", "default"],
-    queryFn: ({ pageParam = 1, signal }) =>
-      fetchCategoryArticles("default", pageParam, 10, signal),
-    getNextPageParam: (lastPage) =>
-      lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
-    initialPageParam: 1,
-  });
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: ["categoryArticles", category],
+      queryFn: ({ pageParam = 1, signal }) =>
+        fetchCategoryArticles(category, pageParam, 10, signal),
+      getNextPageParam: (lastPage) =>
+        lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
+      initialPageParam: 1,
+    });
 
   const articles = data?.pages.flatMap((p) => p.items) ?? [];
 
@@ -51,4 +48,3 @@ export default function CategoryFacet() {
     </FacetPanel>
   );
 }
-

--- a/frontend/app/configurator/FiltersFacet.tsx
+++ b/frontend/app/configurator/FiltersFacet.tsx
@@ -8,19 +8,15 @@ export default function FiltersFacet() {
   const { selections, setSelection } = useSelection();
   const category = selections.category ?? "default";
 
-  const {
-    data,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  } = useInfiniteQuery({
-    queryKey: ["filterOptions", category],
-    queryFn: ({ pageParam = 1, signal }) =>
-      fetchFilterOptions("default", pageParam, 10, signal),
-    getNextPageParam: (lastPage) =>
-      lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
-    initialPageParam: 1,
-  });
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: ["filterOptions", category],
+      queryFn: ({ pageParam = 1, signal }) =>
+        fetchFilterOptions(category, pageParam, 10, signal),
+      getNextPageParam: (lastPage) =>
+        lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
+      initialPageParam: 1,
+    });
 
   const options = data?.pages.flatMap((p) => p.items) ?? [];
 
@@ -49,4 +45,3 @@ export default function FiltersFacet() {
     </FacetPanel>
   );
 }
-

--- a/frontend/app/configurator/__tests__/CategoryFacet.test.tsx
+++ b/frontend/app/configurator/__tests__/CategoryFacet.test.tsx
@@ -1,0 +1,45 @@
+import { render } from "@testing-library/react";
+import CategoryFacet from "@/app/configurator/CategoryFacet";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { fetchCategoryArticles } from "@/lib/api";
+import { useSelection } from "@/components/SelectionProvider";
+
+jest.mock("@tanstack/react-query", () => ({
+  useInfiniteQuery: jest.fn(),
+  useQueryClient: () => ({ invalidateQueries: jest.fn() }),
+}));
+
+jest.mock("@/components/SelectionProvider", () => ({
+  useSelection: jest.fn(),
+}));
+
+jest.mock("@/lib/api", () => ({
+  fetchCategoryArticles: jest.fn(),
+}));
+
+describe("CategoryFacet", () => {
+  it("passes selected category to query and fetch", () => {
+    (useSelection as jest.Mock).mockReturnValue({
+      selections: { category: "books" },
+      setSelection: jest.fn(),
+    });
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
+      data: { pages: [{ items: [] }] },
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    render(<CategoryFacet />);
+
+    const options = (useInfiniteQuery as jest.Mock).mock.calls[0][0];
+    expect(options.queryKey).toEqual(["categoryArticles", "books"]);
+    options.queryFn({ pageParam: 1 });
+    expect(fetchCategoryArticles).toHaveBeenCalledWith(
+      "books",
+      1,
+      10,
+      undefined,
+    );
+  });
+});

--- a/frontend/app/configurator/__tests__/FiltersFacet.test.tsx
+++ b/frontend/app/configurator/__tests__/FiltersFacet.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react";
+import FiltersFacet from "@/app/configurator/FiltersFacet";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { fetchFilterOptions } from "@/lib/api";
+import { useSelection } from "@/components/SelectionProvider";
+
+jest.mock("@tanstack/react-query", () => ({
+  useInfiniteQuery: jest.fn(),
+}));
+
+jest.mock("@/components/SelectionProvider", () => ({
+  useSelection: jest.fn(),
+}));
+
+jest.mock("@/lib/api", () => ({
+  fetchFilterOptions: jest.fn(),
+}));
+
+describe("FiltersFacet", () => {
+  it("fetches filter options for selected category", () => {
+    (useSelection as jest.Mock).mockReturnValue({
+      selections: { category: "books" },
+      setSelection: jest.fn(),
+    });
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
+      data: { pages: [{ items: [] }] },
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    render(<FiltersFacet />);
+
+    const options = (useInfiniteQuery as jest.Mock).mock.calls[0][0];
+    expect(options.queryKey).toEqual(["filterOptions", "books"]);
+    options.queryFn({ pageParam: 1 });
+    expect(fetchFilterOptions).toHaveBeenCalledWith("books", 1, 10, undefined);
+  });
+});

--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -5,4 +5,7 @@ module.exports = {
   transform: {
     '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: { jsx: 'react-jsx' } }],
   },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
 };


### PR DESCRIPTION
## Summary
- Use current category selection when fetching category articles and filters
- Query filter options using the selected category
- Add tests for category-dependent queries and configure Jest path mapping

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bc88a02ee88329bddd448881e25949