### PR TITLE
Specify Docker image versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 1. `cd frontend`
 2. `npm install`
 
+### Docker images
+The `docker-compose.yml` configuration uses specific image tags:
+
+- `prestashop/prestashop:8.1`
+- `node:18.20`
+
 ## Build
 
 - `cd frontend && npm run build:export`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   prestashop:
-    image: prestashop/prestashop:latest
+    image: prestashop/prestashop:8.1
     ports:
       - "8080:80"
     environment:
@@ -25,7 +25,7 @@ services:
       - db_data:/var/lib/mysql
 
   frontend:
-    image: node:18
+    image: node:18.20
     working_dir: /app
     volumes:
       - ./frontend:/app


### PR DESCRIPTION
## Summary
- use prestashop/prestashop:8.1 instead of latest
- pin frontend image to node:18.20
- document docker image versions in README

## Testing
- `cd modules/growset && composer test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bc8a4a05c08329a7cbf3f6dbaf13b8