### PR TITLE
Run module tests before frontend linting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,4 @@
 #!/bin/sh
+set -e
+cd modules/growset && composer test && cd ../..
 cd frontend && npx lint-staged

--- a/modules/growset/composer.json
+++ b/modules/growset/composer.json
@@ -14,6 +14,10 @@
         }
     },
     "scripts": {
-        "test": "phpunit"
+        "lint": "find . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l",
+        "test": [
+            "@lint",
+            "phpunit"
+        ]
     }
 }


### PR DESCRIPTION
## Summary
- Run module PHP tests before frontend linting in pre-commit
- Add PHP linting script and chain it into `composer test`

## Testing
- `composer test`
- `npx --yes lint-staged`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68bc8b77c0fc8329a064bc253cec0d88