### PR TITLE
chore: add index placeholders to module directories

### DIFF
--- a/modules/growset/index.php
+++ b/modules/growset/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/modules/growset/src/Controller/Admin/index.php
+++ b/modules/growset/src/Controller/Admin/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/modules/growset/src/Controller/Api/index.php
+++ b/modules/growset/src/Controller/Api/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/modules/growset/src/Controller/index.php
+++ b/modules/growset/src/Controller/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/modules/growset/src/Service/index.php
+++ b/modules/growset/src/Service/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/modules/growset/src/index.php
+++ b/modules/growset/src/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/modules/growset/tests/index.php
+++ b/modules/growset/tests/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.


### PR DESCRIPTION
## Summary
- prevent directory listing by adding index.php placeholders to the Growset module and its subfolders

## Testing
- `cd modules/growset && composer test`


------
https://chatgpt.com/codex/tasks/task_b_68bc93e948d08329b17047b7020318f2