### PR TITLE
Add frontend hooks for React container

### DIFF
--- a/modules/growset/src/Growset.php
+++ b/modules/growset/src/Growset.php
@@ -32,7 +32,9 @@ class Growset extends Module
         return parent::install()
             && $this->registerHook('actionProductAdd')
             && $this->registerHook('actionProductUpdate')
-            && $this->registerHook('actionProductDelete');
+            && $this->registerHook('actionProductDelete')
+            && $this->registerHook('displayHeader')
+            && $this->registerHook('displayHome');
     }
 
     public function uninstall()
@@ -120,6 +122,28 @@ class Growset extends Module
     public function hookActionProductDelete($params)
     {
         $this->clearProductCache();
+    }
+
+    public function hookDisplayHeader()
+    {
+        if (isset($this->context->controller)) {
+            $this->context->controller->registerStylesheet(
+                'growset-front',
+                'modules/' . $this->name . '/assets/app.css',
+                ['media' => 'all', 'priority' => 150]
+            );
+
+            $this->context->controller->registerJavascript(
+                'growset-front',
+                'modules/' . $this->name . '/assets/app.js',
+                ['position' => 'bottom', 'priority' => 150]
+            );
+        }
+    }
+
+    public function hookDisplayHome()
+    {
+        return '<div id="growset-app"></div>';
     }
 }
 

--- a/modules/growset/tests/GrowsetTest.php
+++ b/modules/growset/tests/GrowsetTest.php
@@ -55,4 +55,12 @@ class GrowsetTest extends TestCase
 
         $this->assertSame(['growset_products'], Cache::$keys);
     }
+
+    public function testDisplayHomeRendersContainer(): void
+    {
+        $module = new Growset();
+        $output = $module->hookDisplayHome([]);
+
+        $this->assertStringContainsString('id="growset-app"', $output);
+    }
 }


### PR DESCRIPTION
## Summary
- Register `displayHeader` and `displayHome` hooks during module installation
- Inject built CSS/JS assets on header display and render a React mount point on home
- Test that the home hook outputs the React container

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68bc96f6fb208329bbad583bc2e2397f