### PR TITLE
Add frontend hooks for React container

### DIFF
--- a/modules/growset/src/Growset.php
+++ b/modules/growset/src/Growset.php
@@ -17,7 +17,7 @@ class Growset extends Module
     {
         $this->name = 'growset';
         $this->tab = 'administration';
-        $this->version = '1.0.0';
+        $this->version = '1.0.1';
         $this->author = 'Growset';
         $this->need_instance = 0;
 

--- a/modules/growset/upgrade/index.php
+++ b/modules/growset/upgrade/index.php
@@ -1,0 +1,3 @@
+<?php
+// Silence is golden
+

--- a/modules/growset/upgrade/upgrade-1.0.1.php
+++ b/modules/growset/upgrade/upgrade-1.0.1.php
@@ -5,6 +5,7 @@ if (!defined('_PS_VERSION_')) {
 
 function upgrade_module_1_0_1($module)
 {
-    return $module->registerHook(['displayHeader', 'displayHome']);
+    return $module->registerHook('displayHeader') &&
+        $module->registerHook('displayHome');
 }
 

--- a/modules/growset/upgrade/upgrade-1.0.1.php
+++ b/modules/growset/upgrade/upgrade-1.0.1.php
@@ -1,0 +1,10 @@
+<?php
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_1_0_1($module)
+{
+    return $module->registerHook(['displayHeader', 'displayHome']);
+}
+


### PR DESCRIPTION
## Summary
- Register `displayHeader` and `displayHome` hooks during module installation
- Inject built CSS/JS assets on header display and render a React mount point on home
- Accept `$params` in display hooks to match PrestaShop signature
- Ensure existing installations register new hooks via upgrade script

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68bc9d476ba4832984b9871a169278dc