### PR TITLE
feat: add product provider service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ frontend/node_modules/
 frontend/out/
 modules/growset/vendor/
 modules/growset/assets/
+modules/growset/.phpunit.result.cache

--- a/modules/growset/phpunit.xml
+++ b/modules/growset/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
     <testsuites>
         <testsuite name="Growset Test Suite">
             <directory>tests</directory>

--- a/modules/growset/src/Controller/Api/FiltersController.php
+++ b/modules/growset/src/Controller/Api/FiltersController.php
@@ -3,7 +3,7 @@
 namespace Growset\Controller\Api;
 
 use Cache;
-use Growset\Service\BackendClient;
+use Growset\Service\ProductProvider;
 use ModuleFrontController;
 use Tools;
 
@@ -22,7 +22,7 @@ class FiltersController extends ModuleFrontController
 
         $content = Cache::retrieve($cacheKey);
         if (!$content) {
-            $client = new BackendClient();
+            $client = new ProductProvider();
             $data = $client->getFilters($page, $limit);
             $content = json_encode([
                 'page' => $page,

--- a/modules/growset/src/Controller/Api/ProductsController.php
+++ b/modules/growset/src/Controller/Api/ProductsController.php
@@ -3,7 +3,7 @@
 namespace Growset\Controller\Api;
 
 use Cache;
-use Growset\Service\BackendClient;
+use Growset\Service\ProductProvider;
 use ModuleFrontController;
 use Tools;
 
@@ -22,7 +22,7 @@ class ProductsController extends ModuleFrontController
 
         $content = Cache::retrieve($cacheKey);
         if (!$content) {
-            $client = new BackendClient();
+            $client = new ProductProvider();
             $data = $client->getProducts($page, $limit);
             $content = json_encode([
                 'page' => $page,

--- a/modules/growset/src/Service/ProductProvider.php
+++ b/modules/growset/src/Service/ProductProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Growset\Service;
+
+use Product;
+use Feature;
+use AttributeGroup;
+use Configuration;
+
+class ProductProvider
+{
+    public function getProducts(int $page, int $limit): array
+    {
+        $idLang = 1;
+        if (class_exists('Context')) {
+            $ctx = \Context::getContext();
+            if (isset($ctx->language) && isset($ctx->language->id)) {
+                $idLang = (int) $ctx->language->id;
+            }
+        } elseif (class_exists('Configuration')) {
+            $idLang = (int) Configuration::get('PS_LANG_DEFAULT', 1);
+        }
+
+        $start = max(0, ($page - 1) * $limit);
+        return Product::getProducts($idLang, $start, $limit, 'id_product', 'ASC');
+    }
+
+    public function getFilters(int $page, int $limit): array
+    {
+        $idLang = 1;
+        if (class_exists('Context')) {
+            $ctx = \Context::getContext();
+            if (isset($ctx->language) && isset($ctx->language->id)) {
+                $idLang = (int) $ctx->language->id;
+            }
+        } elseif (class_exists('Configuration')) {
+            $idLang = (int) Configuration::get('PS_LANG_DEFAULT', 1);
+        }
+
+        $features = Feature::getFeatures($idLang);
+        $attributes = AttributeGroup::getAttributesGroups($idLang);
+
+        $offset = max(0, ($page - 1) * $limit);
+        $features = array_slice($features, $offset, $limit);
+        $attributes = array_slice($attributes, $offset, $limit);
+
+        return [
+            'features' => $features,
+            'attributes' => $attributes,
+        ];
+    }
+}

--- a/modules/growset/tests/ProductProviderTest.php
+++ b/modules/growset/tests/ProductProviderTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Growset\Service\ProductProvider;
+use PHPUnit\Framework\TestCase;
+
+class Product
+{
+    public static function getProducts($idLang, $start, $limit, $orderBy, $orderWay)
+    {
+        return [['id_product' => 1]];
+    }
+}
+
+class Feature
+{
+    public static function getFeatures($idLang)
+    {
+        return [['id_feature' => 1], ['id_feature' => 2]];
+    }
+}
+
+class AttributeGroup
+{
+    public static function getAttributesGroups($idLang)
+    {
+        return [['id_attribute_group' => 1], ['id_attribute_group' => 2]];
+    }
+}
+
+class ProductProviderTest extends TestCase
+{
+    public function testGetProducts()
+    {
+        $provider = new ProductProvider();
+        $products = $provider->getProducts(1, 1);
+        $this->assertSame([['id_product' => 1]], $products);
+    }
+
+    public function testGetFilters()
+    {
+        $provider = new ProductProvider();
+        $filters = $provider->getFilters(1, 1);
+        $this->assertArrayHasKey('features', $filters);
+        $this->assertArrayHasKey('attributes', $filters);
+        $this->assertCount(1, $filters['features']);
+        $this->assertCount(1, $filters['attributes']);
+    }
+}

--- a/modules/growset/tests/bootstrap.php
+++ b/modules/growset/tests/bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+spl_autoload_register(function ($class) {
+    $prefix = 'Growset\\';
+    $baseDir = __DIR__ . '/../src/';
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+    $relative = substr($class, $len);
+    $file = $baseDir . str_replace('\\', '/', $relative) . '.php';
+    if (file_exists($file)) {
+        require $file;
+    }
+});
+
+if (file_exists('/usr/share/php/GuzzleHttp/autoload.php')) {
+    require_once '/usr/share/php/GuzzleHttp/autoload.php';
+}


### PR DESCRIPTION
## Summary
- add ProductProvider service using PrestaShop product and attribute APIs
- switch API controllers to new service
- add bootstrap and tests for ProductProvider

## Testing
- `phpunit -c modules/growset/phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_b_68bca054872483298c96808cb3e184b8