### PR TITLE
feat: add product provider service

### DIFF
--- a/modules/growset/src/Controller/Api/FiltersController.php
+++ b/modules/growset/src/Controller/Api/FiltersController.php
@@ -15,20 +15,17 @@ class FiltersController extends ModuleFrontController
     {
         parent::initContent();
 
+        $facet = (string) Tools::getValue('facet', 'features');
         $page = (int) Tools::getValue('page', 1);
         $limit = (int) Tools::getValue('limit', 20);
-        $cacheKey = sprintf('growset_filters_%d_%d', $page, $limit);
+        $cacheKey = sprintf('growset_filters_%s_%d_%d', $facet, $page, $limit);
         $ttl = 300;
 
         $content = Cache::retrieve($cacheKey);
         if (!$content) {
             $client = new ProductProvider();
-            $data = $client->getFilters($page, $limit);
-            $content = json_encode([
-                'page' => $page,
-                'limit' => $limit,
-                'data' => $data,
-            ]);
+            $data = $client->getFilters($facet, $page, $limit);
+            $content = json_encode($data);
             Cache::store($cacheKey, $content, $ttl);
         }
 

--- a/modules/growset/tests/ProductProviderTest.php
+++ b/modules/growset/tests/ProductProviderTest.php
@@ -15,7 +15,10 @@ class Feature
 {
     public static function getFeatures($idLang)
     {
-        return [['id_feature' => 1], ['id_feature' => 2]];
+        return [
+            ['id_feature' => 1, 'name' => 'Feature 1'],
+            ['id_feature' => 2, 'name' => 'Feature 2'],
+        ];
     }
 }
 
@@ -23,7 +26,10 @@ class AttributeGroup
 {
     public static function getAttributesGroups($idLang)
     {
-        return [['id_attribute_group' => 1], ['id_attribute_group' => 2]];
+        return [
+            ['id_attribute_group' => 1, 'name' => 'Attribute 1'],
+            ['id_attribute_group' => 2, 'name' => 'Attribute 2'],
+        ];
     }
 }
 
@@ -39,10 +45,17 @@ class ProductProviderTest extends TestCase
     public function testGetFilters()
     {
         $provider = new ProductProvider();
-        $filters = $provider->getFilters(1, 1);
-        $this->assertArrayHasKey('features', $filters);
-        $this->assertArrayHasKey('attributes', $filters);
-        $this->assertCount(1, $filters['features']);
-        $this->assertCount(1, $filters['attributes']);
+        $filters = $provider->getFilters('features', 1, 1);
+        $this->assertSame(1, $filters['page']);
+        $this->assertSame(2, $filters['totalPages']);
+        $this->assertCount(1, $filters['items']);
+        $this->assertSame([
+            ['value' => '1', 'label' => 'Feature 1'],
+        ], $filters['items']);
+
+        $attrFilters = $provider->getFilters('attributes', 1, 1);
+        $this->assertSame([
+            ['value' => '1', 'label' => 'Attribute 1'],
+        ], $attrFilters['items']);
     }
 }


### PR DESCRIPTION
## Summary
- map PrestaShop filters to Pagination<FilterOption> shape
- pass facet to FiltersController and adjust caching
- update ProductProvider tests for new shape

## Testing
- `vendor/bin/phpunit -c phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_b_68bca51be6ac8329858c0a6f6b9664f2