### PR TITLE
feat: add category facets with selection management

### DIFF
--- a/frontend/app/configurator/CategoryFacet.tsx
+++ b/frontend/app/configurator/CategoryFacet.tsx
@@ -7,7 +7,8 @@ import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 
 export default function CategoryFacet() {
   const { selections, setSelection } = useSelection();
-  const category = selections.category ?? "default";
+  const selected = selections.category;
+  const category = selected ?? "default";
   const queryClient = useQueryClient();
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -29,8 +30,9 @@ export default function CategoryFacet() {
           <ArticleListItem
             key={article.id}
             article={article}
-            onSelect={(id) => {
-              setSelection("category", id);
+            selected={article.id === selected}
+            onToggle={(id) => {
+              setSelection("category", id === selected ? null : id);
               queryClient.invalidateQueries({ queryKey: ["filterOptions"] });
             }}
           />

--- a/frontend/app/configurator/FanFacet.tsx
+++ b/frontend/app/configurator/FanFacet.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { fetchCategoryArticles } from "@/lib/api";
+import ArticleListItem from "@/components/ArticleListItem";
+import FacetPanel from "@/components/FacetPanel";
+import { useSelection } from "@/components/SelectionProvider";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+export default function FanFacet() {
+  const { selections, setSelection } = useSelection();
+  const selected = selections.fan;
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: ["fanArticles"],
+      queryFn: ({ pageParam = 1, signal }) =>
+        fetchCategoryArticles("fan", pageParam, 10, signal),
+      getNextPageParam: (lastPage) =>
+        lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
+      initialPageParam: 1,
+    });
+
+  const articles = data?.pages.flatMap((p) => p.items) ?? [];
+
+  return (
+    <FacetPanel title="Lüfter">
+      <ul className="space-y-2">
+        {articles.map((article) => (
+          <ArticleListItem
+            key={article.id}
+            article={article}
+            selected={article.id === selected}
+            onToggle={(id) => setSelection("fan", id === selected ? null : id)}
+          />
+        ))}
+      </ul>
+      {hasNextPage && (
+        <button
+          className="mt-2 rounded bg-gray-200 px-3 py-1"
+          onClick={() => fetchNextPage()}
+          disabled={isFetchingNextPage}
+        >
+          {isFetchingNextPage ? "Loading..." : "Load more"}
+        </button>
+      )}
+    </FacetPanel>
+  );
+}

--- a/frontend/app/configurator/GrowboxFacet.tsx
+++ b/frontend/app/configurator/GrowboxFacet.tsx
@@ -1,0 +1,49 @@
+"use client";
+import { fetchCategoryArticles } from "@/lib/api";
+import ArticleListItem from "@/components/ArticleListItem";
+import FacetPanel from "@/components/FacetPanel";
+import { useSelection } from "@/components/SelectionProvider";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+export default function GrowboxFacet() {
+  const { selections, setSelection } = useSelection();
+  const selected = selections.growbox;
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: ["growboxArticles"],
+      queryFn: ({ pageParam = 1, signal }) =>
+        fetchCategoryArticles("growbox", pageParam, 10, signal),
+      getNextPageParam: (lastPage) =>
+        lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
+      initialPageParam: 1,
+    });
+
+  const articles = data?.pages.flatMap((p) => p.items) ?? [];
+
+  return (
+    <FacetPanel title="Growbox">
+      <ul className="space-y-2">
+        {articles.map((article) => (
+          <ArticleListItem
+            key={article.id}
+            article={article}
+            selected={article.id === selected}
+            onToggle={(id) =>
+              setSelection("growbox", id === selected ? null : id)
+            }
+          />
+        ))}
+      </ul>
+      {hasNextPage && (
+        <button
+          className="mt-2 rounded bg-gray-200 px-3 py-1"
+          onClick={() => fetchNextPage()}
+          disabled={isFetchingNextPage}
+        >
+          {isFetchingNextPage ? "Loading..." : "Load more"}
+        </button>
+      )}
+    </FacetPanel>
+  );
+}

--- a/frontend/app/configurator/LedFacet.tsx
+++ b/frontend/app/configurator/LedFacet.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { fetchCategoryArticles } from "@/lib/api";
+import ArticleListItem from "@/components/ArticleListItem";
+import FacetPanel from "@/components/FacetPanel";
+import { useSelection } from "@/components/SelectionProvider";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+export default function LedFacet() {
+  const { selections, setSelection } = useSelection();
+  const growbox = selections.growbox;
+  const selected = selections.led;
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: ["ledArticles", growbox],
+      queryFn: ({ pageParam = 1, signal }) =>
+        fetchCategoryArticles("led", pageParam, 10, signal, growbox),
+      getNextPageParam: (lastPage) =>
+        lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
+      initialPageParam: 1,
+    });
+
+  const articles = data?.pages.flatMap((p) => p.items) ?? [];
+
+  return (
+    <FacetPanel title="Grow-LED">
+      <ul className="space-y-2">
+        {articles.map((article) => (
+          <ArticleListItem
+            key={article.id}
+            article={article}
+            selected={article.id === selected}
+            onToggle={(id) => setSelection("led", id === selected ? null : id)}
+          />
+        ))}
+      </ul>
+      {hasNextPage && (
+        <button
+          className="mt-2 rounded bg-gray-200 px-3 py-1"
+          onClick={() => fetchNextPage()}
+          disabled={isFetchingNextPage}
+        >
+          {isFetchingNextPage ? "Loading..." : "Load more"}
+        </button>
+      )}
+    </FacetPanel>
+  );
+}

--- a/frontend/app/configurator/__tests__/LedFacet.test.tsx
+++ b/frontend/app/configurator/__tests__/LedFacet.test.tsx
@@ -1,0 +1,45 @@
+import { render } from "@testing-library/react";
+import LedFacet from "@/app/configurator/LedFacet";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { fetchCategoryArticles } from "@/lib/api";
+import { useSelection } from "@/components/SelectionProvider";
+
+jest.mock("@tanstack/react-query", () => ({
+  useInfiniteQuery: jest.fn(),
+}));
+
+jest.mock("@/components/SelectionProvider", () => ({
+  useSelection: jest.fn(),
+}));
+
+jest.mock("@/lib/api", () => ({
+  fetchCategoryArticles: jest.fn(),
+}));
+
+describe("LedFacet", () => {
+  it("filters LEDs by selected growbox", () => {
+    (useSelection as jest.Mock).mockReturnValue({
+      selections: { growbox: "g1", led: null },
+      setSelection: jest.fn(),
+    });
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
+      data: { pages: [{ items: [] }] },
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    render(<LedFacet />);
+
+    const options = (useInfiniteQuery as jest.Mock).mock.calls[0][0];
+    expect(options.queryKey).toEqual(["ledArticles", "g1"]);
+    options.queryFn({ pageParam: 1 });
+    expect(fetchCategoryArticles).toHaveBeenCalledWith(
+      "led",
+      1,
+      10,
+      undefined,
+      "g1",
+    );
+  });
+});

--- a/frontend/app/configurator/page.tsx
+++ b/frontend/app/configurator/page.tsx
@@ -1,13 +1,15 @@
-import CategoryFacet from "./CategoryFacet";
-import FiltersFacet from "./FiltersFacet";
+import GrowboxFacet from "./GrowboxFacet";
+import LedFacet from "./LedFacet";
+import FanFacet from "./FanFacet";
 import SetSummary from "@/components/SetSummary";
 
 export default function ConfiguratorPage() {
   return (
     <div className="grid gap-4 md:grid-cols-3">
       <div className="space-y-4 md:col-span-2">
-        <CategoryFacet />
-        <FiltersFacet />
+        <GrowboxFacet />
+        <LedFacet />
+        <FanFacet />
       </div>
       <SetSummary />
     </div>

--- a/frontend/components/ArticleListItem.tsx
+++ b/frontend/components/ArticleListItem.tsx
@@ -8,20 +8,32 @@ interface Article {
 
 export default function ArticleListItem({
   article,
-  onSelect,
+  selected = false,
+  onToggle,
 }: {
   article: Article;
-  onSelect?: (id: string) => void;
+  selected?: boolean;
+  onToggle?: (id: string) => void;
 }) {
   return (
-    <li
-      className="cursor-pointer rounded border p-2 hover:bg-gray-50"
-      onClick={() => onSelect?.(article.id)}
-    >
-      <h3 className="font-medium">{article.title}</h3>
-      {article.description && (
-        <p className="text-sm text-gray-600">{article.description}</p>
-      )}
+    <li className="rounded border p-2 hover:bg-gray-50">
+      <div className="flex items-center justify-between">
+        <div
+          className="flex-1 cursor-pointer"
+          onClick={() => onToggle?.(article.id)}
+        >
+          <h3 className="font-medium">{article.title}</h3>
+          {article.description && (
+            <p className="text-sm text-gray-600">{article.description}</p>
+          )}
+        </div>
+        <button
+          className="ml-2 rounded bg-green-500 px-2 py-1 text-sm text-white"
+          onClick={() => onToggle?.(article.id)}
+        >
+          {selected ? "Im Set" : "Ins Set"}
+        </button>
+      </div>
     </li>
   );
 }

--- a/frontend/components/SelectionProvider.tsx
+++ b/frontend/components/SelectionProvider.tsx
@@ -3,16 +3,26 @@ import { createContext, useContext, useState, ReactNode } from "react";
 
 interface SelectionContextValue {
   selections: Record<string, string>;
-  setSelection: (facet: string, value: string) => void;
+  setSelection: (facet: string, value: string | null) => void;
 }
 
-const SelectionContext = createContext<SelectionContextValue | undefined>(undefined);
+const SelectionContext = createContext<SelectionContextValue | undefined>(
+  undefined,
+);
 
 export function SelectionProvider({ children }: { children: ReactNode }) {
   const [selections, setSelections] = useState<Record<string, string>>({});
 
-  const setSelection = (facet: string, value: string) => {
-    setSelections((prev) => ({ ...prev, [facet]: value }));
+  const setSelection = (facet: string, value: string | null) => {
+    setSelections((prev) => {
+      const next = { ...prev };
+      if (value === null) {
+        delete next[facet];
+      } else {
+        next[facet] = value;
+      }
+      return next;
+    });
   };
 
   return (
@@ -24,6 +34,7 @@ export function SelectionProvider({ children }: { children: ReactNode }) {
 
 export function useSelection() {
   const ctx = useContext(SelectionContext);
-  if (!ctx) throw new Error("useSelection must be used within SelectionProvider");
+  if (!ctx)
+    throw new Error("useSelection must be used within SelectionProvider");
   return ctx;
 }

--- a/frontend/components/__tests__/ArticleListItem.test.tsx
+++ b/frontend/components/__tests__/ArticleListItem.test.tsx
@@ -3,7 +3,13 @@ import ArticleListItem from "../ArticleListItem";
 
 describe("ArticleListItem", () => {
   it("renders article title", () => {
-    render(<ArticleListItem article={{ id: "1", title: "My Article" }} />);
+    render(
+      <ArticleListItem
+        article={{ id: "1", title: "My Article" }}
+        onToggle={jest.fn()}
+      />,
+    );
     expect(screen.getByText("My Article")).toBeInTheDocument();
+    expect(screen.getByText("Ins Set")).toBeInTheDocument();
   });
 });

--- a/frontend/components/__tests__/SetSummary.test.tsx
+++ b/frontend/components/__tests__/SetSummary.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import SetSummary from "../SetSummary";
+import { SelectionProvider, useSelection } from "../SelectionProvider";
+
+function Wrapper() {
+  const { setSelection } = useSelection();
+  return (
+    <>
+      <button onClick={() => setSelection("growbox", "1")}>Select</button>
+      <SetSummary />
+    </>
+  );
+}
+
+describe("SetSummary", () => {
+  it("updates when selections change", () => {
+    render(
+      <SelectionProvider>
+        <Wrapper />
+      </SelectionProvider>,
+    );
+
+    expect(
+      screen.queryAllByText((content, el) => el?.textContent === "growbox: 1")
+        .length,
+    ).toBe(0);
+    fireEvent.click(screen.getByText("Select"));
+    expect(
+      screen.getAllByText((content, el) => el?.textContent === "growbox: 1")
+        .length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -19,11 +19,13 @@ export async function fetchCategoryArticles(
   signal?: AbortSignal,
   relatedId?: string,
 ): Promise<Pagination<Article>> {
-  const url = new URL(`${API_BASE}/categories/${category}/articles`);
-  url.searchParams.set("page", String(page));
-  url.searchParams.set("limit", String(limit));
-  if (relatedId) url.searchParams.set("related", relatedId);
-  const res = await fetch(url.toString(), { signal });
+  const params = new URLSearchParams({
+    page: String(page),
+    limit: String(limit),
+  });
+  if (relatedId) params.set("related", relatedId);
+  const url = `${API_BASE}/categories/${category}/articles?${params.toString()}`;
+  const res = await fetch(url, { signal });
   if (!res.ok) throw new Error("Failed to fetch category articles");
   return res.json();
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -16,19 +16,21 @@ export async function fetchCategoryArticles(
   category: string,
   page = 1,
   limit = 10,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  relatedId?: string,
 ): Promise<Pagination<Article>> {
-  const res = await fetch(
-    `${API_BASE}/categories/${category}/articles?page=${page}&limit=${limit}`,
-    { signal }
-  );
+  const url = new URL(`${API_BASE}/categories/${category}/articles`);
+  url.searchParams.set("page", String(page));
+  url.searchParams.set("limit", String(limit));
+  if (relatedId) url.searchParams.set("related", relatedId);
+  const res = await fetch(url.toString(), { signal });
   if (!res.ok) throw new Error("Failed to fetch category articles");
   return res.json();
 }
 
 export async function fetchArticle(
   id: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ): Promise<Article> {
   const res = await fetch(`${API_BASE}/articles/${id}`, { signal });
   if (!res.ok) throw new Error("Failed to fetch article");
@@ -44,13 +46,12 @@ export async function fetchFilterOptions(
   facet: string,
   page = 1,
   limit = 10,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ): Promise<Pagination<FilterOption>> {
   const res = await fetch(
     `${API_BASE}/filters/${facet}?page=${page}&limit=${limit}`,
-    { signal }
+    { signal },
   );
   if (!res.ok) throw new Error("Failed to fetch filter options");
   return res.json();
 }
-


### PR DESCRIPTION
## Summary
- add dedicated Growbox, LED and fan facets
- enable toggling selections with "Ins Set"/"Im Set" buttons and summary
- filter LED options by selected growbox
- test reactive updates

## Testing
- `npm test --prefix frontend`
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_b_68bca753fe648329b63edfdf4f711c44