### PR TITLE
fix: restore category selection and safe URL building

### DIFF
--- a/frontend/app/configurator/CategoryFacet.tsx
+++ b/frontend/app/configurator/CategoryFacet.tsx
@@ -7,7 +7,8 @@ import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 
 export default function CategoryFacet() {
   const { selections, setSelection } = useSelection();
-  const category = selections.category ?? "default";
+  const selected = selections.category;
+  const category = selected ?? "default";
   const queryClient = useQueryClient();
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -29,8 +30,9 @@ export default function CategoryFacet() {
           <ArticleListItem
             key={article.id}
             article={article}
-            onSelect={(id) => {
-              setSelection("category", id);
+            selected={article.id === selected}
+            onToggle={(id) => {
+              setSelection("category", id === selected ? null : id);
               queryClient.invalidateQueries({ queryKey: ["filterOptions"] });
             }}
           />

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -19,11 +19,13 @@ export async function fetchCategoryArticles(
   signal?: AbortSignal,
   relatedId?: string,
 ): Promise<Pagination<Article>> {
-  const url = new URL(`${API_BASE}/categories/${category}/articles`);
-  url.searchParams.set("page", String(page));
-  url.searchParams.set("limit", String(limit));
-  if (relatedId) url.searchParams.set("related", relatedId);
-  const res = await fetch(url.toString(), { signal });
+  const params = new URLSearchParams({
+    page: String(page),
+    limit: String(limit),
+  });
+  if (relatedId) params.set("related", relatedId);
+  const url = `${API_BASE}/categories/${category}/articles?${params.toString()}`;
+  const res = await fetch(url, { signal });
   if (!res.ok) throw new Error("Failed to fetch category articles");
   return res.json();
 }


### PR DESCRIPTION
## Summary
- build category article URLs without `new URL` to allow relative API base
- wire category facet to use `onToggle` and selection state

## Testing
- `npm test --prefix frontend`
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_b_68bcaa0a1e6c83298ad84befd581c55f