### PR TITLE
Validate page and limit parameters in API controllers

### DIFF
--- a/modules/growset/src/Controller/Api/FiltersController.php
+++ b/modules/growset/src/Controller/Api/FiltersController.php
@@ -17,6 +17,12 @@ class FiltersController extends ModuleFrontController
 
         $page = (int) Tools::getValue('page', 1);
         $limit = (int) Tools::getValue('limit', 20);
+        if ($page < 1 || $limit < 1 || $limit > 100) {
+            header('Content-Type: application/json');
+            header('HTTP/1.1 400 Bad Request');
+            echo json_encode(['error' => 'Invalid page or limit']);
+            exit;
+        }
         $cacheKey = sprintf('growset_filters_%d_%d', $page, $limit);
         $ttl = 300;
 

--- a/modules/growset/src/Controller/Api/ProductsController.php
+++ b/modules/growset/src/Controller/Api/ProductsController.php
@@ -17,6 +17,12 @@ class ProductsController extends ModuleFrontController
 
         $page = (int) Tools::getValue('page', 1);
         $limit = (int) Tools::getValue('limit', 20);
+        if ($page < 1 || $limit < 1 || $limit > 100) {
+            header('Content-Type: application/json');
+            header('HTTP/1.1 400 Bad Request');
+            echo json_encode(['error' => 'Invalid page or limit']);
+            exit;
+        }
         $cacheKey = sprintf('growset_products_%d_%d', $page, $limit);
         $ttl = 300;
 


### PR DESCRIPTION
## Summary
- validate `page` and `limit` request parameters for API filters/products endpoints
- return HTTP 400 with error JSON when parameters out of range

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_b_68bcb59397ac83298582b70ba32554ca