### PR TITLE
Refactor pagination validation into shared trait

### DIFF
--- a/modules/growset2/src/Controller/Api/FiltersController.php
+++ b/modules/growset2/src/Controller/Api/FiltersController.php
@@ -5,12 +5,13 @@ namespace Growset2\Controller\Api;
 use Cache;
 use Growset2\Service\ProductProvider;
 use ModuleFrontController;
-use Tools;
 use Growset2\Controller\Api\JsonResponseTrait;
+use Growset2\Controller\Api\PaginationValidatorTrait;
 
 class FiltersController extends ModuleFrontController
 {
     use JsonResponseTrait;
+    use PaginationValidatorTrait;
 
     public $ssl = true;
 
@@ -18,14 +19,7 @@ class FiltersController extends ModuleFrontController
     {
         parent::initContent();
 
-        $page = (int) Tools::getValue('page', 1);
-        $limit = (int) Tools::getValue('limit', 20);
-        if ($page < 1 || $limit < 1 || $limit > 100) {
-            header('Content-Type: application/json');
-            header('HTTP/1.1 400 Bad Request');
-            echo json_encode(['error' => 'Invalid page or limit']);
-            exit;
-        }
+        list($page, $limit) = $this->validatePagination();
         $cacheKey = sprintf('growset2_filters_%d_%d', $page, $limit);
         $ttl = 300;
 

--- a/modules/growset2/src/Controller/Api/PaginationValidatorTrait.php
+++ b/modules/growset2/src/Controller/Api/PaginationValidatorTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Growset2\Controller\Api;
+
+use Tools;
+
+trait PaginationValidatorTrait
+{
+    protected function validatePagination(): array
+    {
+        $page = (int) Tools::getValue('page', 1);
+        $limit = (int) Tools::getValue('limit', 20);
+        if ($page < 1 || $limit < 1 || $limit > 100) {
+            header('Content-Type: application/json');
+            header('HTTP/1.1 400 Bad Request');
+            echo json_encode(['error' => 'Invalid page or limit']);
+            exit;
+        }
+        return [$page, $limit];
+    }
+}

--- a/modules/growset2/src/Controller/Api/ProductsController.php
+++ b/modules/growset2/src/Controller/Api/ProductsController.php
@@ -5,12 +5,13 @@ namespace Growset2\Controller\Api;
 use Cache;
 use Growset2\Service\ProductProvider;
 use ModuleFrontController;
-use Tools;
 use Growset2\Controller\Api\JsonResponseTrait;
+use Growset2\Controller\Api\PaginationValidatorTrait;
 
 class ProductsController extends ModuleFrontController
 {
     use JsonResponseTrait;
+    use PaginationValidatorTrait;
 
     public $ssl = true;
 
@@ -18,14 +19,7 @@ class ProductsController extends ModuleFrontController
     {
         parent::initContent();
 
-        $page = (int) Tools::getValue('page', 1);
-        $limit = (int) Tools::getValue('limit', 20);
-        if ($page < 1 || $limit < 1 || $limit > 100) {
-            header('Content-Type: application/json');
-            header('HTTP/1.1 400 Bad Request');
-            echo json_encode(['error' => 'Invalid page or limit']);
-            exit;
-        }
+        list($page, $limit) = $this->validatePagination();
         $cacheKey = sprintf('growset2_products_%d_%d', $page, $limit);
         $ttl = 300;
 


### PR DESCRIPTION
## Summary
- extract common page/limit validation into `PaginationValidatorTrait`
- reuse `validatePagination()` in FiltersController and ProductsController

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68bd888d9410832999e58710412b8c75