### PR TITLE
Remove duplicate module build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,14 @@ The `docker-compose.yml` configuration uses specific image tags:
 
 ## Build
 
-- `cd frontend && npm run build:export`
-- Generated assets will be copied to `modules/growset2/assets`.
+Run the frontend build and export:
+
+```bash
+cd frontend
+npm run build:export
+```
+
+The generated assets are copied to `modules/growset2/assets`.
 
 ## Deployment
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,6 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
-    "module": "npm run build && cp -r out ../modules/growset2/assets",
     "build:export": "npm run build && cp -r out ../modules/growset2/assets",
     "prepare": "cd .. && husky install",
     "test": "jest"


### PR DESCRIPTION
## Summary
- remove unused `module` script from frontend package.json
- document `npm run build:export` as the build/export workflow

## Testing
- `cd frontend && npm test`
- `git commit` hook: `composer test`

------
https://chatgpt.com/codex/tasks/task_b_68bd9237fd508329b31fc92460fa1de3