### PR TITLE
refactor: introduce generic ArticleFacet

### DIFF
--- a/frontend/app/configurator/ArticleFacet.tsx
+++ b/frontend/app/configurator/ArticleFacet.tsx
@@ -1,0 +1,69 @@
+"use client";
+import { fetchCategoryArticles } from "@/lib/api";
+import ArticleListItem from "@/components/ArticleListItem";
+import FacetPanel from "@/components/FacetPanel";
+import { useSelection } from "@/components/SelectionProvider";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+interface ArticleFacetProps {
+  category: string;
+  selectionKey: string;
+  title: string;
+  queryKey?: unknown[];
+  fetchArgs?: (string | undefined)[];
+  onSelect?: (id: string | null) => void;
+}
+
+export default function ArticleFacet({
+  category,
+  selectionKey,
+  title,
+  queryKey,
+  fetchArgs = [],
+  onSelect,
+}: ArticleFacetProps) {
+  const { selections, setSelection } = useSelection();
+  const selected = selections[selectionKey];
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: queryKey ?? [`${selectionKey}Articles`, category],
+      queryFn: ({ pageParam = 1, signal }) =>
+        fetchCategoryArticles(category, pageParam, 10, signal, ...fetchArgs),
+      getNextPageParam: (lastPage) =>
+        lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
+      initialPageParam: 1,
+    });
+
+  const articles = data?.pages.flatMap((p) => p.items) ?? [];
+
+  const handleToggle = (id: string) => {
+    const next = id === selected ? null : id;
+    setSelection(selectionKey, next);
+    onSelect?.(next);
+  };
+
+  return (
+    <FacetPanel title={title}>
+      <ul className="space-y-2">
+        {articles.map((article) => (
+          <ArticleListItem
+            key={article.id}
+            article={article}
+            selected={article.id === selected}
+            onToggle={handleToggle}
+          />
+        ))}
+      </ul>
+      {hasNextPage && (
+        <button
+          className="mt-2 rounded bg-gray-200 px-3 py-1"
+          onClick={() => fetchNextPage()}
+          disabled={isFetchingNextPage}
+        >
+          {isFetchingNextPage ? "Loading..." : "Load more"}
+        </button>
+      )}
+    </FacetPanel>
+  );
+}

--- a/frontend/app/configurator/CategoryFacet.tsx
+++ b/frontend/app/configurator/CategoryFacet.tsx
@@ -1,52 +1,22 @@
 "use client";
-import { fetchCategoryArticles } from "@/lib/api";
-import ArticleListItem from "@/components/ArticleListItem";
-import FacetPanel from "@/components/FacetPanel";
+import ArticleFacet from "./ArticleFacet";
 import { useSelection } from "@/components/SelectionProvider";
-import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 
 export default function CategoryFacet() {
-  const { selections, setSelection } = useSelection();
-  const selected = selections.category;
-  const category = selected ?? "default";
+  const { selections } = useSelection();
+  const category = selections.category ?? "default";
   const queryClient = useQueryClient();
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useInfiniteQuery({
-      queryKey: ["categoryArticles", category],
-      queryFn: ({ pageParam = 1, signal }) =>
-        fetchCategoryArticles(category, pageParam, 10, signal),
-      getNextPageParam: (lastPage) =>
-        lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
-      initialPageParam: 1,
-    });
-
-  const articles = data?.pages.flatMap((p) => p.items) ?? [];
-
   return (
-    <FacetPanel title="Articles">
-      <ul className="space-y-2">
-        {articles.map((article) => (
-          <ArticleListItem
-            key={article.id}
-            article={article}
-            selected={article.id === selected}
-            onToggle={(id) => {
-              setSelection("category", id === selected ? null : id);
-              queryClient.invalidateQueries({ queryKey: ["filterOptions"] });
-            }}
-          />
-        ))}
-      </ul>
-      {hasNextPage && (
-        <button
-          className="mt-2 rounded bg-gray-200 px-3 py-1"
-          onClick={() => fetchNextPage()}
-          disabled={isFetchingNextPage}
-        >
-          {isFetchingNextPage ? "Loading..." : "Load more"}
-        </button>
-      )}
-    </FacetPanel>
+    <ArticleFacet
+      category={category}
+      selectionKey="category"
+      title="Articles"
+      queryKey={["categoryArticles", category]}
+      onSelect={() =>
+        queryClient.invalidateQueries({ queryKey: ["filterOptions"] })
+      }
+    />
   );
 }

--- a/frontend/app/configurator/FanFacet.tsx
+++ b/frontend/app/configurator/FanFacet.tsx
@@ -1,47 +1,13 @@
 "use client";
-import { fetchCategoryArticles } from "@/lib/api";
-import ArticleListItem from "@/components/ArticleListItem";
-import FacetPanel from "@/components/FacetPanel";
-import { useSelection } from "@/components/SelectionProvider";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import ArticleFacet from "./ArticleFacet";
 
 export default function FanFacet() {
-  const { selections, setSelection } = useSelection();
-  const selected = selections.fan;
-
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useInfiniteQuery({
-      queryKey: ["fanArticles"],
-      queryFn: ({ pageParam = 1, signal }) =>
-        fetchCategoryArticles("fan", pageParam, 10, signal),
-      getNextPageParam: (lastPage) =>
-        lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
-      initialPageParam: 1,
-    });
-
-  const articles = data?.pages.flatMap((p) => p.items) ?? [];
-
   return (
-    <FacetPanel title="Lüfter">
-      <ul className="space-y-2">
-        {articles.map((article) => (
-          <ArticleListItem
-            key={article.id}
-            article={article}
-            selected={article.id === selected}
-            onToggle={(id) => setSelection("fan", id === selected ? null : id)}
-          />
-        ))}
-      </ul>
-      {hasNextPage && (
-        <button
-          className="mt-2 rounded bg-gray-200 px-3 py-1"
-          onClick={() => fetchNextPage()}
-          disabled={isFetchingNextPage}
-        >
-          {isFetchingNextPage ? "Loading..." : "Load more"}
-        </button>
-      )}
-    </FacetPanel>
+    <ArticleFacet
+      category="fan"
+      selectionKey="fan"
+      title="Lüfter"
+      queryKey={["fanArticles"]}
+    />
   );
 }

--- a/frontend/app/configurator/GrowboxFacet.tsx
+++ b/frontend/app/configurator/GrowboxFacet.tsx
@@ -1,49 +1,13 @@
 "use client";
-import { fetchCategoryArticles } from "@/lib/api";
-import ArticleListItem from "@/components/ArticleListItem";
-import FacetPanel from "@/components/FacetPanel";
-import { useSelection } from "@/components/SelectionProvider";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import ArticleFacet from "./ArticleFacet";
 
 export default function GrowboxFacet() {
-  const { selections, setSelection } = useSelection();
-  const selected = selections.growbox;
-
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useInfiniteQuery({
-      queryKey: ["growboxArticles"],
-      queryFn: ({ pageParam = 1, signal }) =>
-        fetchCategoryArticles("growbox", pageParam, 10, signal),
-      getNextPageParam: (lastPage) =>
-        lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
-      initialPageParam: 1,
-    });
-
-  const articles = data?.pages.flatMap((p) => p.items) ?? [];
-
   return (
-    <FacetPanel title="Growbox">
-      <ul className="space-y-2">
-        {articles.map((article) => (
-          <ArticleListItem
-            key={article.id}
-            article={article}
-            selected={article.id === selected}
-            onToggle={(id) =>
-              setSelection("growbox", id === selected ? null : id)
-            }
-          />
-        ))}
-      </ul>
-      {hasNextPage && (
-        <button
-          className="mt-2 rounded bg-gray-200 px-3 py-1"
-          onClick={() => fetchNextPage()}
-          disabled={isFetchingNextPage}
-        >
-          {isFetchingNextPage ? "Loading..." : "Load more"}
-        </button>
-      )}
-    </FacetPanel>
+    <ArticleFacet
+      category="growbox"
+      selectionKey="growbox"
+      title="Growbox"
+      queryKey={["growboxArticles"]}
+    />
   );
 }

--- a/frontend/app/configurator/LedFacet.tsx
+++ b/frontend/app/configurator/LedFacet.tsx
@@ -1,48 +1,18 @@
 "use client";
-import { fetchCategoryArticles } from "@/lib/api";
-import ArticleListItem from "@/components/ArticleListItem";
-import FacetPanel from "@/components/FacetPanel";
+import ArticleFacet from "./ArticleFacet";
 import { useSelection } from "@/components/SelectionProvider";
-import { useInfiniteQuery } from "@tanstack/react-query";
 
 export default function LedFacet() {
-  const { selections, setSelection } = useSelection();
+  const { selections } = useSelection();
   const growbox = selections.growbox;
-  const selected = selections.led;
-
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useInfiniteQuery({
-      queryKey: ["ledArticles", growbox],
-      queryFn: ({ pageParam = 1, signal }) =>
-        fetchCategoryArticles("led", pageParam, 10, signal, growbox),
-      getNextPageParam: (lastPage) =>
-        lastPage.page < lastPage.totalPages ? lastPage.page + 1 : undefined,
-      initialPageParam: 1,
-    });
-
-  const articles = data?.pages.flatMap((p) => p.items) ?? [];
 
   return (
-    <FacetPanel title="Grow-LED">
-      <ul className="space-y-2">
-        {articles.map((article) => (
-          <ArticleListItem
-            key={article.id}
-            article={article}
-            selected={article.id === selected}
-            onToggle={(id) => setSelection("led", id === selected ? null : id)}
-          />
-        ))}
-      </ul>
-      {hasNextPage && (
-        <button
-          className="mt-2 rounded bg-gray-200 px-3 py-1"
-          onClick={() => fetchNextPage()}
-          disabled={isFetchingNextPage}
-        >
-          {isFetchingNextPage ? "Loading..." : "Load more"}
-        </button>
-      )}
-    </FacetPanel>
+    <ArticleFacet
+      category="led"
+      selectionKey="led"
+      title="Grow-LED"
+      queryKey={["ledArticles", growbox]}
+      fetchArgs={[growbox]}
+    />
   );
 }

--- a/frontend/app/configurator/__tests__/FanFacet.test.tsx
+++ b/frontend/app/configurator/__tests__/FanFacet.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react";
+import FanFacet from "@/app/configurator/FanFacet";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { fetchCategoryArticles } from "@/lib/api";
+import { useSelection } from "@/components/SelectionProvider";
+
+jest.mock("@tanstack/react-query", () => ({
+  useInfiniteQuery: jest.fn(),
+}));
+
+jest.mock("@/components/SelectionProvider", () => ({
+  useSelection: jest.fn(),
+}));
+
+jest.mock("@/lib/api", () => ({
+  fetchCategoryArticles: jest.fn(),
+}));
+
+describe("FanFacet", () => {
+  it("fetches fan articles", () => {
+    (useSelection as jest.Mock).mockReturnValue({
+      selections: { fan: null },
+      setSelection: jest.fn(),
+    });
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
+      data: { pages: [{ items: [] }] },
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    render(<FanFacet />);
+
+    const options = (useInfiniteQuery as jest.Mock).mock.calls[0][0];
+    expect(options.queryKey).toEqual(["fanArticles"]);
+    options.queryFn({ pageParam: 1 });
+    expect(fetchCategoryArticles).toHaveBeenCalledWith("fan", 1, 10, undefined);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable `ArticleFacet` component for category-based article facets
- refactor Category, Fan, Growbox and Led facets to use new component
- test fan facet article fetching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bd943410148329b8ce8f5f90e3c84d