### PR TITLE
Refactor test stubs to avoid global namespace pollution

### DIFF
--- a/modules/growset2/tests/Growset2Test.php
+++ b/modules/growset2/tests/Growset2Test.php
@@ -1,5 +1,52 @@
 <?php
 
+namespace Growset2\Tests;
+
+use Growset2\Growset2;
+use Growset2\Tests\Stubs\Cache as CacheStub;
+use Growset2\Tests\Stubs\Module as ModuleStub;
+use PHPUnit\Framework\TestCase;
+
+class Growset2Test extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists('Module', false)) {
+            class_alias(ModuleStub::class, 'Module');
+        }
+        if (!class_exists('Cache', false)) {
+            class_alias(CacheStub::class, 'Cache');
+        }
+        CacheStub::$keys = [];
+    }
+
+    public function testAddHookClearsCache(): void
+    {
+        $module = new Growset2();
+        $module->hookActionProductAdd([]);
+
+        $this->assertSame(['growset2_products'], CacheStub::$keys);
+    }
+
+    public function testUpdateHookClearsCache(): void
+    {
+        $module = new Growset2();
+        $module->hookActionProductUpdate([]);
+
+        $this->assertSame(['growset2_products'], CacheStub::$keys);
+    }
+
+    public function testDeleteHookClearsCache(): void
+    {
+        $module = new Growset2();
+        $module->hookActionProductDelete([]);
+
+        $this->assertSame(['growset2_products'], CacheStub::$keys);
+    }
+}
+
+namespace Growset2\Tests\Stubs;
+
 class Module
 {
     public function __construct()
@@ -19,40 +66,5 @@ class Cache
     public static function clean(string $key): void
     {
         self::$keys[] = $key;
-    }
-}
-
-use Growset2\Growset2;
-use PHPUnit\Framework\TestCase;
-
-class Growset2Test extends TestCase
-{
-    protected function setUp(): void
-    {
-        Cache::$keys = [];
-    }
-
-    public function testAddHookClearsCache(): void
-    {
-        $module = new Growset2();
-        $module->hookActionProductAdd([]);
-
-        $this->assertSame(['growset2_products'], Cache::$keys);
-    }
-
-    public function testUpdateHookClearsCache(): void
-    {
-        $module = new Growset2();
-        $module->hookActionProductUpdate([]);
-
-        $this->assertSame(['growset2_products'], Cache::$keys);
-    }
-
-    public function testDeleteHookClearsCache(): void
-    {
-        $module = new Growset2();
-        $module->hookActionProductDelete([]);
-
-        $this->assertSame(['growset2_products'], Cache::$keys);
     }
 }

--- a/modules/growset2/tests/ProductProviderTest.php
+++ b/modules/growset2/tests/ProductProviderTest.php
@@ -1,7 +1,47 @@
 <?php
 
+namespace Growset2\Tests;
+
 use Growset2\Service\ProductProvider;
+use Growset2\Tests\Stubs\AttributeGroup as AttributeGroupStub;
+use Growset2\Tests\Stubs\Feature as FeatureStub;
+use Growset2\Tests\Stubs\Product as ProductStub;
 use PHPUnit\Framework\TestCase;
+
+class ProductProviderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists('Product', false)) {
+            class_alias(ProductStub::class, 'Product');
+        }
+        if (!class_exists('Feature', false)) {
+            class_alias(FeatureStub::class, 'Feature');
+        }
+        if (!class_exists('AttributeGroup', false)) {
+            class_alias(AttributeGroupStub::class, 'AttributeGroup');
+        }
+    }
+
+    public function testGetProducts()
+    {
+        $provider = new ProductProvider();
+        $products = $provider->getProducts(1, 1);
+        $this->assertSame([['id_product' => 1]], $products);
+    }
+
+    public function testGetFilters()
+    {
+        $provider = new ProductProvider();
+        $filters = $provider->getFilters(1, 1);
+        $this->assertArrayHasKey('features', $filters);
+        $this->assertArrayHasKey('attributes', $filters);
+        $this->assertCount(1, $filters['features']);
+        $this->assertCount(1, $filters['attributes']);
+    }
+}
+
+namespace Growset2\Tests\Stubs;
 
 class Product
 {
@@ -24,25 +64,5 @@ class AttributeGroup
     public static function getAttributesGroups($idLang)
     {
         return [['id_attribute_group' => 1], ['id_attribute_group' => 2]];
-    }
-}
-
-class ProductProviderTest extends TestCase
-{
-    public function testGetProducts()
-    {
-        $provider = new ProductProvider();
-        $products = $provider->getProducts(1, 1);
-        $this->assertSame([['id_product' => 1]], $products);
-    }
-
-    public function testGetFilters()
-    {
-        $provider = new ProductProvider();
-        $filters = $provider->getFilters(1, 1);
-        $this->assertArrayHasKey('features', $filters);
-        $this->assertArrayHasKey('attributes', $filters);
-        $this->assertCount(1, $filters['features']);
-        $this->assertCount(1, $filters['attributes']);
     }
 }


### PR DESCRIPTION
## Summary
- replace global stub classes in tests with namespaced stubs
- alias stubs to global names during setup for ProductProvider and Growset2

## Testing
- `cd modules/growset2 && ./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_b_68bdf0527de883299bfe6cef69e13212