### PR TITLE
ci: verify exported assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,14 @@ jobs:
         run: npm run lint
         working-directory: frontend
 
-      - name: Build and export
-        run: npm run build:export
-        working-directory: frontend
+      - name: Verify exported assets
+        run: |
+          npm --prefix frontend run build:export
+          if [ -n "$(git status --porcelain modules/growset2/assets)" ]; then
+            echo 'modules/growset2/assets is out of date. Run npm run build:export and commit the results.'
+            git status --porcelain modules/growset2/assets
+            exit 1
+          fi
 
       - name: Upload exported assets
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 
 frontend/node_modules/
 frontend/out/
+frontend/.next/
 modules/growset2/.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ npm run build:export
 ```
 
 The generated assets are copied to `modules/growset2/assets`.
+Commit the updated assets; the CI pipeline rebuilds and fails if this directory
+differs from the freshly generated output.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- verify frontend export matches committed module assets in CI
- ignore Next.js build output
- document automatic asset verification in README

## Testing
- `composer test` *(fails: phpunit not found)*
- `npm test`
- `npm --prefix frontend run build:export`


------
https://chatgpt.com/codex/tasks/task_b_68bdf5ddc14483299dd831b2f6c85cfb