### PR TITLE
Use rsync for frontend export and document procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,17 @@ The `docker-compose.yml` configuration uses specific image tags:
 
 ## Build
 
-Run the frontend build and export:
+Run the frontend build and export. This builds the Next.js frontend and
+synchronizes the exported files into the module's `assets` directory:
 
 ```bash
 cd frontend
 npm run build:export
 ```
 
-The generated assets are copied to `modules/growset2/assets`.
+The script clears any existing files in `modules/growset2/assets` and then
+uses `rsync` to copy the contents of the `out` directory. The module's front
+controller loads `assets/index.html` as the entry point.
 
 ## Deployment
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "build:export": "npm run build && cp -r out ../modules/growset2/assets",
+    "build:export": "npm run build && rm -rf ../modules/growset2/assets && mkdir -p ../modules/growset2/assets && rsync -a --delete out/ ../modules/growset2/assets/",
     "prepare": "cd .. && husky install",
     "test": "jest"
   },

--- a/modules/growset2/controllers/front/display.php
+++ b/modules/growset2/controllers/front/display.php
@@ -1,9 +1,17 @@
 <?php
+/**
+ * Front controller that serves the pre-built frontend.
+ *
+ * The `assets` directory is populated by `npm run build:export` which
+ * synchronizes the Next.js export into `modules/growset2/assets`. The
+ * generated `index.html` acts as the entry point for the module frontend.
+ */
 class Growset2DisplayModuleFrontController extends ModuleFrontController
 {
     public function initContent()
     {
         parent::initContent();
+        // Redirect to the exported frontend entry point.
         Tools::redirect($this->module->getPathUri() . 'assets/index.html', null);
     }
 }


### PR DESCRIPTION
## Summary
- replace `cp -r out` with an `rsync` command that syncs the build output into the module's `assets` directory
- document the export process and add comments in the front controller explaining how assets are served

## Testing
- `cd frontend && npm test`
- `cd modules/growset2 && composer test`


------
https://chatgpt.com/codex/tasks/task_b_68be019dd74483299b72a400bf1146cb