### PR TITLE
Use manual HTTP redirect in front display controller

### DIFF
--- a/modules/growset2/controllers/front/display.php
+++ b/modules/growset2/controllers/front/display.php
@@ -12,6 +12,8 @@ class Growset2DisplayModuleFrontController extends ModuleFrontController
     {
         parent::initContent();
         // Redirect to the exported frontend entry point.
-        Tools::redirect($this->module->getPathUri() . 'assets/index.html', null);
+        $url = $this->module->getPathUri() . 'assets/index.html';
+        header('Location: ' . $url, true, 302);
+        exit;
     }
 }


### PR DESCRIPTION
## Summary
- ensure growset display controller redirects with standard HTTP headers instead of `Tools::redirect`

## Testing
- `composer test` (from `modules/growset2`)
- `curl -I 127.0.0.1:8000` on test script verifying 302 redirect


------
https://chatgpt.com/codex/tasks/task_b_68be069629608329a9cef41637533219