### PR TITLE
Add category dropdown sections with hierarchy

### DIFF
--- a/modules/growset2/src/Growset2.php
+++ b/modules/growset2/src/Growset2.php
@@ -3,13 +3,20 @@
 namespace Growset2;
 
 use Cache;
+use Category;
 use Configuration;
 use Module;
 use Tools;
 
 class Growset2 extends Module
 {
-    public const CONFIG_CATEGORY_IDS = 'GROWSET2_CATEGORY_IDS';
+    public const CONFIG_GROWBOX_CATEGORY = 'GROWSET2_GROWBOX_CATEGORY_ID';
+    public const CONFIG_GROWLED_CATEGORY = 'GROWSET2_GROWLED_CATEGORY_ID';
+    public const CONFIG_ABLUFT_VENTILATOR_CATEGORY = 'GROWSET2_ABLUFT_VENTILATOR_CATEGORY_ID';
+    public const CONFIG_AKTIVKOHLEFILTER_CATEGORY = 'GROWSET2_AKTIVKOHLEFILTER_CATEGORY_ID';
+    public const CONFIG_ABLUFTSCHLAUCH_CATEGORY = 'GROWSET2_ABLUFTSCHLAUCH_CATEGORY_ID';
+    public const CONFIG_UMLUFTVENTILATOR_CATEGORY = 'GROWSET2_UMLUFTVENTILATOR_CATEGORY_ID';
+    public const CONFIG_CONTROLLER_CATEGORY = 'GROWSET2_CONTROLLER_CATEGORY_ID';
     public const CONFIG_BACKEND_URL = 'GROWSET2_BACKEND_URL';
     public const CONFIG_TOKEN = 'GROWSET2_BACKEND_TOKEN';
 
@@ -37,7 +44,13 @@ class Growset2 extends Module
 
     public function uninstall()
     {
-        Configuration::deleteByName(self::CONFIG_CATEGORY_IDS);
+        Configuration::deleteByName(self::CONFIG_GROWBOX_CATEGORY);
+        Configuration::deleteByName(self::CONFIG_GROWLED_CATEGORY);
+        Configuration::deleteByName(self::CONFIG_ABLUFT_VENTILATOR_CATEGORY);
+        Configuration::deleteByName(self::CONFIG_AKTIVKOHLEFILTER_CATEGORY);
+        Configuration::deleteByName(self::CONFIG_ABLUFTSCHLAUCH_CATEGORY);
+        Configuration::deleteByName(self::CONFIG_UMLUFTVENTILATOR_CATEGORY);
+        Configuration::deleteByName(self::CONFIG_CONTROLLER_CATEGORY);
         Configuration::deleteByName(self::CONFIG_BACKEND_URL);
         Configuration::deleteByName(self::CONFIG_TOKEN);
 
@@ -48,9 +61,15 @@ class Growset2 extends Module
     {
         $output = '';
         if (Tools::isSubmit('submitGrowset2')) {
-            Configuration::updateValue(self::CONFIG_CATEGORY_IDS, Tools::getValue(self::CONFIG_CATEGORY_IDS));
-            Configuration::updateValue(self::CONFIG_BACKEND_URL, Tools::getValue(self::CONFIG_BACKEND_URL));
-            Configuration::updateValue(self::CONFIG_TOKEN, Tools::getValue(self::CONFIG_TOKEN));
+            $this->updateConfigValue(self::CONFIG_GROWBOX_CATEGORY);
+            $this->updateConfigValue(self::CONFIG_GROWLED_CATEGORY);
+            $this->updateConfigValue(self::CONFIG_ABLUFT_VENTILATOR_CATEGORY);
+            $this->updateConfigValue(self::CONFIG_AKTIVKOHLEFILTER_CATEGORY);
+            $this->updateConfigValue(self::CONFIG_ABLUFTSCHLAUCH_CATEGORY);
+            $this->updateConfigValue(self::CONFIG_UMLUFTVENTILATOR_CATEGORY);
+            $this->updateConfigValue(self::CONFIG_CONTROLLER_CATEGORY);
+            $this->updateConfigValue(self::CONFIG_BACKEND_URL);
+            $this->updateConfigValue(self::CONFIG_TOKEN);
             $output .= $this->displayConfirmation($this->l('Settings updated'));
         }
 
@@ -61,15 +80,139 @@ class Growset2 extends Module
     {
         $defaultLang = (int) Configuration::get('PS_LANG_DEFAULT');
 
-        $fieldsForm[0]['form'] = [
-            'legend' => ['title' => $this->l('Settings')],
-            'input' => [
-                [
-                    'type' => 'text',
-                    'label' => $this->l('Category IDs'),
-                    'name' => self::CONFIG_CATEGORY_IDS,
-                    'desc' => $this->l('Comma separated category identifiers'),
+        $categories = $this->getCategoryOptions($defaultLang);
+
+        $forms = [];
+
+        $forms[]['form'] = [
+            'legend' => ['title' => $this->l('Growbox')],
+            'input' => [[
+                'type' => 'select',
+                'label' => $this->l('Category'),
+                'name' => self::CONFIG_GROWBOX_CATEGORY,
+                'options' => [
+                    'query' => $categories,
+                    'id' => 'id_category',
+                    'name' => 'name',
                 ],
+            ]],
+            'submit' => [
+                'title' => $this->l('Save'),
+                'class' => 'btn btn-default pull-right',
+            ],
+        ];
+
+        $forms[]['form'] = [
+            'legend' => ['title' => $this->l('Grow LED')],
+            'input' => [[
+                'type' => 'select',
+                'label' => $this->l('Category'),
+                'name' => self::CONFIG_GROWLED_CATEGORY,
+                'options' => [
+                    'query' => $categories,
+                    'id' => 'id_category',
+                    'name' => 'name',
+                ],
+            ]],
+            'submit' => [
+                'title' => $this->l('Save'),
+                'class' => 'btn btn-default pull-right',
+            ],
+        ];
+
+        $forms[]['form'] = [
+            'legend' => ['title' => $this->l('Abluft Ventilator')],
+            'input' => [[
+                'type' => 'select',
+                'label' => $this->l('Category'),
+                'name' => self::CONFIG_ABLUFT_VENTILATOR_CATEGORY,
+                'options' => [
+                    'query' => $categories,
+                    'id' => 'id_category',
+                    'name' => 'name',
+                ],
+            ]],
+            'submit' => [
+                'title' => $this->l('Save'),
+                'class' => 'btn btn-default pull-right',
+            ],
+        ];
+
+        $forms[]['form'] = [
+            'legend' => ['title' => $this->l('Aaktivkohlefilter')],
+            'input' => [[
+                'type' => 'select',
+                'label' => $this->l('Category'),
+                'name' => self::CONFIG_AKTIVKOHLEFILTER_CATEGORY,
+                'options' => [
+                    'query' => $categories,
+                    'id' => 'id_category',
+                    'name' => 'name',
+                ],
+            ]],
+            'submit' => [
+                'title' => $this->l('Save'),
+                'class' => 'btn btn-default pull-right',
+            ],
+        ];
+
+        $forms[]['form'] = [
+            'legend' => ['title' => $this->l('Abluftschlauch')],
+            'input' => [[
+                'type' => 'select',
+                'label' => $this->l('Category'),
+                'name' => self::CONFIG_ABLUFTSCHLAUCH_CATEGORY,
+                'options' => [
+                    'query' => $categories,
+                    'id' => 'id_category',
+                    'name' => 'name',
+                ],
+            ]],
+            'submit' => [
+                'title' => $this->l('Save'),
+                'class' => 'btn btn-default pull-right',
+            ],
+        ];
+
+        $forms[]['form'] = [
+            'legend' => ['title' => $this->l('Umluftventilator')],
+            'input' => [[
+                'type' => 'select',
+                'label' => $this->l('Category'),
+                'name' => self::CONFIG_UMLUFTVENTILATOR_CATEGORY,
+                'options' => [
+                    'query' => $categories,
+                    'id' => 'id_category',
+                    'name' => 'name',
+                ],
+            ]],
+            'submit' => [
+                'title' => $this->l('Save'),
+                'class' => 'btn btn-default pull-right',
+            ],
+        ];
+
+        $forms[]['form'] = [
+            'legend' => ['title' => $this->l('Controller')],
+            'input' => [[
+                'type' => 'select',
+                'label' => $this->l('Category'),
+                'name' => self::CONFIG_CONTROLLER_CATEGORY,
+                'options' => [
+                    'query' => $categories,
+                    'id' => 'id_category',
+                    'name' => 'name',
+                ],
+            ]],
+            'submit' => [
+                'title' => $this->l('Save'),
+                'class' => 'btn btn-default pull-right',
+            ],
+        ];
+
+        $forms[]['form'] = [
+            'legend' => ['title' => $this->l('Backend Settings')],
+            'input' => [
                 [
                     'type' => 'text',
                     'label' => $this->l('Backend URL'),
@@ -95,9 +238,33 @@ class Growset2 extends Module
         $helper->token = \Tools::getAdminTokenLite('AdminModules');
         $helper->default_form_language = $defaultLang;
 
-        $helper->fields_value[self::CONFIG_CATEGORY_IDS] = $this->getConfigValue(
-            self::CONFIG_CATEGORY_IDS,
-            'GROWSET2_CATEGORY_IDS'
+        $helper->fields_value[self::CONFIG_GROWBOX_CATEGORY] = $this->getConfigValue(
+            self::CONFIG_GROWBOX_CATEGORY,
+            'GROWSET2_GROWBOX_CATEGORY_ID'
+        );
+        $helper->fields_value[self::CONFIG_GROWLED_CATEGORY] = $this->getConfigValue(
+            self::CONFIG_GROWLED_CATEGORY,
+            'GROWSET2_GROWLED_CATEGORY_ID'
+        );
+        $helper->fields_value[self::CONFIG_ABLUFT_VENTILATOR_CATEGORY] = $this->getConfigValue(
+            self::CONFIG_ABLUFT_VENTILATOR_CATEGORY,
+            'GROWSET2_ABLUFT_VENTILATOR_CATEGORY_ID'
+        );
+        $helper->fields_value[self::CONFIG_AKTIVKOHLEFILTER_CATEGORY] = $this->getConfigValue(
+            self::CONFIG_AKTIVKOHLEFILTER_CATEGORY,
+            'GROWSET2_AKTIVKOHLEFILTER_CATEGORY_ID'
+        );
+        $helper->fields_value[self::CONFIG_ABLUFTSCHLAUCH_CATEGORY] = $this->getConfigValue(
+            self::CONFIG_ABLUFTSCHLAUCH_CATEGORY,
+            'GROWSET2_ABLUFTSCHLAUCH_CATEGORY_ID'
+        );
+        $helper->fields_value[self::CONFIG_UMLUFTVENTILATOR_CATEGORY] = $this->getConfigValue(
+            self::CONFIG_UMLUFTVENTILATOR_CATEGORY,
+            'GROWSET2_UMLUFTVENTILATOR_CATEGORY_ID'
+        );
+        $helper->fields_value[self::CONFIG_CONTROLLER_CATEGORY] = $this->getConfigValue(
+            self::CONFIG_CONTROLLER_CATEGORY,
+            'GROWSET2_CONTROLLER_CATEGORY_ID'
         );
         $helper->fields_value[self::CONFIG_BACKEND_URL] = $this->getConfigValue(
             self::CONFIG_BACKEND_URL,
@@ -108,13 +275,44 @@ class Growset2 extends Module
             'GROWSET2_BACKEND_TOKEN'
         );
 
-        return $helper->generateForm($fieldsForm);
+        return $helper->generateForm($forms);
     }
 
     private function getConfigValue(string $key, string $envKey)
     {
         return Configuration::get($key)
             ?: getenv($envKey);
+    }
+
+    private function updateConfigValue(string $key): void
+    {
+        $value = Tools::getValue($key, null);
+        if ($value !== null) {
+            Configuration::updateValue($key, $value);
+        }
+    }
+
+    protected function getCategoryOptions(int $idLang): array
+    {
+        $tree = Category::getNestedCategories(null, $idLang, true);
+        $options = [];
+        $this->flattenCategories($tree, $options);
+        return $options;
+    }
+
+    private function flattenCategories(array $categories, array &$options, int $depth = 0): void
+    {
+        foreach ($categories as $category) {
+            $prefix = '|';
+            $prefix .= $depth === 0 ? '-' : str_repeat('---', $depth);
+            $options[] = [
+                'id_category' => $category['id_category'],
+                'name' => $prefix . $category['name'],
+            ];
+            if (!empty($category['children'])) {
+                $this->flattenCategories($category['children'], $options, $depth + 1);
+            }
+        }
     }
 
     private function clearProductCache(): void

--- a/modules/growset2/src/Service/ProductProvider.php
+++ b/modules/growset2/src/Service/ProductProvider.php
@@ -14,14 +14,43 @@ class ProductProvider
     {
         $idLang = $this->getLanguageId();
 
-        $rawIds = '';
-        if (class_exists('Configuration')) {
-            $rawIds = (string) Configuration::get(Growset2::CONFIG_CATEGORY_IDS);
+        $keys = [
+            Growset2::CONFIG_GROWBOX_CATEGORY,
+            Growset2::CONFIG_GROWLED_CATEGORY,
+            Growset2::CONFIG_ABLUFT_VENTILATOR_CATEGORY,
+            Growset2::CONFIG_AKTIVKOHLEFILTER_CATEGORY,
+            Growset2::CONFIG_ABLUFTSCHLAUCH_CATEGORY,
+            Growset2::CONFIG_UMLUFTVENTILATOR_CATEGORY,
+            Growset2::CONFIG_CONTROLLER_CATEGORY,
+        ];
+
+        $categoryIds = [];
+        foreach ($keys as $key) {
+            $id = 0;
+            if (class_exists('Configuration')) {
+                $id = (int) Configuration::get($key);
+            }
+            if ($id <= 0) {
+                $id = (int) getenv($key);
+            }
+            if ($id > 0) {
+                $categoryIds[] = $id;
+            }
         }
-        if ($rawIds === '') {
-            $rawIds = (string) getenv('GROWSET2_CATEGORY_IDS');
+        $categoryIds = array_values(array_unique($categoryIds));
+
+        if (empty($categoryIds)) {
+            $rawIds = '';
+            if (class_exists('Configuration')) {
+                $rawIds = (string) Configuration::get('GROWSET2_CATEGORY_IDS');
+            }
+            if ($rawIds === '') {
+                $rawIds = (string) getenv('GROWSET2_CATEGORY_IDS');
+            }
+            if ($rawIds !== '') {
+                $categoryIds = array_values(array_filter(array_map('intval', preg_split('/\s*,\s*/', $rawIds, -1, PREG_SPLIT_NO_EMPTY))));
+            }
         }
-        $categoryIds = array_values(array_filter(array_map('intval', preg_split('/\s*,\s*/', (string) $rawIds, -1, PREG_SPLIT_NO_EMPTY))));
 
         if (empty($categoryIds)) {
             $start = max(0, ($page - 1) * $limit);


### PR DESCRIPTION
## Summary
- add individual config sections to select PrestaShop categories for Growbox, Grow LED, ventilation and more
- support backend URL and token plus new hierarchical category dropdowns
- build category tree rendering with prefixes for hierarchy
- update product provider to gather selected categories from new per-section config keys and environment variable fallbacks
- fall back to legacy `GROWSET2_CATEGORY_IDS` configuration entry so upgrades retain existing category filters

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68be0b31aa108329b8adff31c4a0732c