### PR TITLE
Replace plus/minus icons with arrows in facet panels

### DIFF
--- a/frontend/components/FacetPanel.tsx
+++ b/frontend/components/FacetPanel.tsx
@@ -27,7 +27,7 @@ export default function FacetPanel({
         onClick={() => setOpen((o) => !o)}
       >
         <span>{title}</span>
-        <span>{open ? "-" : "+"}</span>
+        <span>{open ? "↑" : "↓"}</span>
       </button>
       {open ? (
         <div className="p-4">{children}</div>


### PR DESCRIPTION
## Summary
- use arrow up/down icons instead of plus/minus for `FacetPanel` toggle

## Testing
- `cd modules/growset2 && composer test`
- `cd frontend && npm test`
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68be2daa67508329b83dbbf933d46a38