### PR TITLE
Handle category slugs and IDs for configurator

### DIFF
--- a/frontend/app/configurator/CarbonFilterFacet.tsx
+++ b/frontend/app/configurator/CarbonFilterFacet.tsx
@@ -2,9 +2,10 @@
 import ArticleFacet from "./ArticleFacet";
 
 export default function CarbonFilterFacet() {
+  const category = process.env.NEXT_PUBLIC_CARBON_FILTER_CATEGORY_ID || "";
   return (
     <ArticleFacet
-      category="carbon-filter"
+      category={category}
       selectionKey="carbonFilter"
       title="Aktivkohlefilter"
       queryKey={["carbonFilterArticles"]}

--- a/frontend/app/configurator/CirculationFanFacet.tsx
+++ b/frontend/app/configurator/CirculationFanFacet.tsx
@@ -2,9 +2,10 @@
 import ArticleFacet from "./ArticleFacet";
 
 export default function CirculationFanFacet() {
+  const category = process.env.NEXT_PUBLIC_CIRCULATION_FAN_CATEGORY_ID || "";
   return (
     <ArticleFacet
-      category="circulation-fan"
+      category={category}
       selectionKey="circulationFan"
       title="Umluftventilator"
       queryKey={["circulationFanArticles"]}

--- a/frontend/app/configurator/ControllerFacet.tsx
+++ b/frontend/app/configurator/ControllerFacet.tsx
@@ -2,9 +2,10 @@
 import ArticleFacet from "./ArticleFacet";
 
 export default function ControllerFacet() {
+  const category = process.env.NEXT_PUBLIC_CONTROLLER_CATEGORY_ID || "";
   return (
     <ArticleFacet
-      category="controller"
+      category={category}
       selectionKey="controller"
       title="Controller"
       queryKey={["controllerArticles"]}

--- a/frontend/app/configurator/DuctFacet.tsx
+++ b/frontend/app/configurator/DuctFacet.tsx
@@ -2,9 +2,10 @@
 import ArticleFacet from "./ArticleFacet";
 
 export default function DuctFacet() {
+  const category = process.env.NEXT_PUBLIC_DUCT_CATEGORY_ID || "";
   return (
     <ArticleFacet
-      category="duct"
+      category={category}
       selectionKey="duct"
       title="Abluftschlauch"
       queryKey={["ductArticles"]}

--- a/frontend/app/configurator/ExhaustFanFacet.tsx
+++ b/frontend/app/configurator/ExhaustFanFacet.tsx
@@ -2,9 +2,10 @@
 import ArticleFacet from "./ArticleFacet";
 
 export default function ExhaustFanFacet() {
+  const category = process.env.NEXT_PUBLIC_EXHAUST_FAN_CATEGORY_ID || "";
   return (
     <ArticleFacet
-      category="exhaust-fan"
+      category={category}
       selectionKey="exhaustFan"
       title="Abluft Ventilator"
       queryKey={["exhaustFanArticles"]}

--- a/frontend/app/configurator/GrowboxFacet.tsx
+++ b/frontend/app/configurator/GrowboxFacet.tsx
@@ -2,9 +2,10 @@
 import ArticleFacet from "./ArticleFacet";
 
 export default function GrowboxFacet() {
+  const category = process.env.NEXT_PUBLIC_GROWBOX_CATEGORY_ID || "";
   return (
     <ArticleFacet
-      category="growbox"
+      category={category}
       selectionKey="growbox"
       title="Growbox"
       queryKey={["growboxArticles"]}

--- a/frontend/app/configurator/LedFacet.tsx
+++ b/frontend/app/configurator/LedFacet.tsx
@@ -6,9 +6,11 @@ export default function LedFacet() {
   const { selections } = useSelection();
   const growbox = selections.growbox;
 
+  const category = process.env.NEXT_PUBLIC_LED_CATEGORY_ID || "";
+
   return (
     <ArticleFacet
-      category="led"
+      category={category}
       selectionKey="led"
       title="Grow-LED"
       queryKey={["ledArticles", growbox]}

--- a/frontend/app/configurator/__tests__/ExhaustFanFacet.test.tsx
+++ b/frontend/app/configurator/__tests__/ExhaustFanFacet.test.tsx
@@ -18,6 +18,7 @@ jest.mock("@/lib/api", () => ({
 
 describe("ExhaustFanFacet", () => {
   it("fetches exhaust fan articles", () => {
+    process.env.NEXT_PUBLIC_EXHAUST_FAN_CATEGORY_ID = "2";
     (useSelection as jest.Mock).mockReturnValue({
       selections: { exhaustFan: null },
       setSelection: jest.fn(),
@@ -34,11 +35,6 @@ describe("ExhaustFanFacet", () => {
     const options = (useInfiniteQuery as jest.Mock).mock.calls[0][0];
     expect(options.queryKey).toEqual(["exhaustFanArticles"]);
     options.queryFn({ pageParam: 1 });
-    expect(fetchCategoryArticles).toHaveBeenCalledWith(
-      "exhaust-fan",
-      1,
-      10,
-      undefined,
-    );
+    expect(fetchCategoryArticles).toHaveBeenCalledWith("2", 1, 10, undefined);
   });
 });

--- a/frontend/app/configurator/__tests__/LedFacet.test.tsx
+++ b/frontend/app/configurator/__tests__/LedFacet.test.tsx
@@ -18,6 +18,7 @@ jest.mock("@/lib/api", () => ({
 
 describe("LedFacet", () => {
   it("filters LEDs by selected growbox", () => {
+    process.env.NEXT_PUBLIC_LED_CATEGORY_ID = "1";
     (useSelection as jest.Mock).mockReturnValue({
       selections: { growbox: "g1", led: null },
       setSelection: jest.fn(),
@@ -35,7 +36,7 @@ describe("LedFacet", () => {
     expect(options.queryKey).toEqual(["ledArticles", "g1"]);
     options.queryFn({ pageParam: 1 });
     expect(fetchCategoryArticles).toHaveBeenCalledWith(
-      "led",
+      "1",
       1,
       10,
       undefined,

--- a/modules/growset2/src/Controller/Api/CategoryArticlesController.php
+++ b/modules/growset2/src/Controller/Api/CategoryArticlesController.php
@@ -6,6 +6,8 @@ use ModuleFrontController;
 use Growset2\Controller\Api\JsonResponseTrait;
 use Growset2\Controller\Api\PaginationValidatorTrait;
 use Growset2\Service\ProductProvider;
+use Growset2\Growset2;
+use Configuration;
 use Tools;
 
 class CategoryArticlesController extends ModuleFrontController
@@ -21,6 +23,26 @@ class CategoryArticlesController extends ModuleFrontController
 
         $categoryParam = Tools::getValue('category');
         $categoryId = $categoryParam !== null ? (int) $categoryParam : 0;
+
+        if ($categoryId <= 0 && is_string($categoryParam)) {
+            $slug = $categoryParam;
+            $map = [
+                'growbox' => Growset2::CONFIG_GROWBOX_CATEGORY,
+                'led' => Growset2::CONFIG_GROWLED_CATEGORY,
+                'exhaust-fan' => Growset2::CONFIG_ABLUFT_VENTILATOR_CATEGORY,
+                'carbon-filter' => Growset2::CONFIG_AKTIVKOHLEFILTER_CATEGORY,
+                'duct' => Growset2::CONFIG_ABLUFTSCHLAUCH_CATEGORY,
+                'circulation-fan' => Growset2::CONFIG_UMLUFTVENTILATOR_CATEGORY,
+                'controller' => Growset2::CONFIG_CONTROLLER_CATEGORY,
+            ];
+            if (isset($map[$slug])) {
+                $configKey = $map[$slug];
+                $categoryId = (int) Configuration::get($configKey);
+                if ($categoryId <= 0) {
+                    $categoryId = (int) getenv($configKey);
+                }
+            }
+        }
         if ($categoryId <= 0 && isset($_SERVER['REQUEST_URI'])) {
             if (preg_match('#/categories/(\d+)/articles#', $_SERVER['REQUEST_URI'], $m)) {
                 $categoryId = (int) $m[1];


### PR DESCRIPTION
## Summary
- Map category slugs to configuration IDs in the API controller
- Read category IDs from environment variables in facet components
- Update unit tests to expect numeric category IDs

## Testing
- `cd modules/growset2 && composer test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c73e55d3988328a5930ecd0a9a4763